### PR TITLE
feat: sync active punishments to Redis for multi-proxy Velocity setups

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation(mn.micronaut.flyway)
     runtimeOnly("org.flywaydb:flyway-mysql:10.22.0")
     implementation(mn.micronaut.rabbitmq)
+    implementation(mn.micronaut.redis.lettuce)
     implementation(mn.micronaut.hibernate.validator)
     implementation(mn.micronaut.data.tx.hibernate)
     implementation(mn.micronaut.jdbc.hikari)

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/BlackholeApplication.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/BlackholeApplication.java
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.info.License;
 @OpenAPIDefinition(
         info = @Info(
                 title = "Blackhole API",
-                version = "0.0.3",
+                version = "0.0.4",
                 description = "Simple ban management system",
                 license = @License(name = "Close Source"),
                 contact = @Contact(

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/controller/AppealController.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/controller/AppealController.java
@@ -211,7 +211,8 @@ public class AppealController {
                 "appealIdentifier", identifier.toString(),
                 "owner", appeal.getAppellantHash(),
                 "punishmentIdentifier", punishment.getIdentifier(),
-                "decision", review.decision().toString()
+                "decision", review.decision().toString(),
+                "type", punishment.getType().toString()
         ));
 
         return HttpResponse.ok(saved.toDTO());

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/controller/PunishmentEntityController.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/controller/PunishmentEntityController.java
@@ -101,6 +101,96 @@ public class PunishmentEntityController {
     }
 
     /**
+     * Revoke an active ban.
+     *
+     * @param tenantId the tenant the punishment belongs to
+     * @param owner the owner of the punishment
+     * @param source the staff/system identity revoking the punishment
+     * @return the updated profile
+     */
+    @Operation(
+            summary = "Revoke active ban",
+            description = "Revokes a player's active ban (SERVER or NETWORK), moving it into history",
+            operationId = "revokeBan",
+            tags = {"Punishment"}
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Ban successfully revoked",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PunishProfileResponse.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Profile not found, or has no active ban"
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "Invalid input parameters (owner must be SHA-512 hash)"
+    )
+    @Validated
+    @Post("/active/{tenantId}/{owner}/ban/revoke/{source}")
+    public HttpResponse<PunishProfileResponse> revokeBan(
+            UUID tenantId,
+            @Valid @Pattern(regexp = "^[a-fA-F0-9]{128}$", message = "Owner must be a sha-512 hash") String owner,
+            UUID source
+    ) {
+        this.tenantContext.requireTenantAccess(tenantId);
+        var profile = this.punishmentApplicationService.revokeBan(tenantId, owner, source);
+        if (profile.isEmpty()) {
+            return HttpResponse.notFound();
+        }
+        return HttpResponse.ok(profile.get().toDTO());
+    }
+
+    /**
+     * Revoke an active mute.
+     *
+     * @param tenantId the tenant the punishment belongs to
+     * @param owner the owner of the punishment
+     * @param source the staff/system identity revoking the punishment
+     * @return the updated profile
+     */
+    @Operation(
+            summary = "Revoke active mute",
+            description = "Revokes a player's active chat ban, moving it into history",
+            operationId = "revokeMute",
+            tags = {"Punishment"}
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Mute successfully revoked",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PunishProfileResponse.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Profile not found, or has no active mute"
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "Invalid input parameters (owner must be SHA-512 hash)"
+    )
+    @Validated
+    @Post("/active/{tenantId}/{owner}/mute/revoke/{source}")
+    public HttpResponse<PunishProfileResponse> revokeMute(
+            UUID tenantId,
+            @Valid @Pattern(regexp = "^[a-fA-F0-9]{128}$", message = "Owner must be a sha-512 hash") String owner,
+            UUID source
+    ) {
+        this.tenantContext.requireTenantAccess(tenantId);
+        var profile = this.punishmentApplicationService.revokeMute(tenantId, owner, source);
+        if (profile.isEmpty()) {
+            return HttpResponse.notFound();
+        }
+        return HttpResponse.ok(profile.get().toDTO());
+    }
+
+    /**
      * Get all punishments from the database.
      *
      * @return a list with all punishments

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/events/BlackholeRabbitTopology.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/events/BlackholeRabbitTopology.java
@@ -52,5 +52,11 @@ public class BlackholeRabbitTopology extends ChannelInitializer {
 
         channel.queueDeclare(RabbitTopology.ELO_SIGNAL_QUEUE, true, false, false, null);
         channel.queueBind(RabbitTopology.ELO_SIGNAL_QUEUE, RabbitTopology.EVENTS_EXCHANGE, "signal.#");
+
+        channel.queueDeclare(RabbitTopology.REDIS_SYNC_QUEUE, true, false, false, null);
+        channel.queueBind(RabbitTopology.REDIS_SYNC_QUEUE, RabbitTopology.EVENTS_EXCHANGE, "punishment.created");
+        channel.queueBind(RabbitTopology.REDIS_SYNC_QUEUE, RabbitTopology.EVENTS_EXCHANGE, "punishment.expired");
+        channel.queueBind(RabbitTopology.REDIS_SYNC_QUEUE, RabbitTopology.EVENTS_EXCHANGE, "punishment.revoked");
+        channel.queueBind(RabbitTopology.REDIS_SYNC_QUEUE, RabbitTopology.EVENTS_EXCHANGE, "appeal.resolved");
     }
 }

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/events/RabbitTopology.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/events/RabbitTopology.java
@@ -46,6 +46,17 @@ public final class RabbitTopology {
      */
     public static final String ELO_SIGNAL_QUEUE = "blackhole.elo.signal";
 
+    /**
+     * Durable queue bound to {@link #EVENTS_EXCHANGE} with routing keys {@code punishment.created},
+     * {@code punishment.expired}, {@code punishment.revoked} and {@code appeal.resolved} - feeds
+     * {@code RedisSyncConsumer}, which mirrors active-punishment state into Redis so every
+     * Velocity proxy in a multi-proxy network sees consistent ban/mute state without querying
+     * this API on every login/chat message. A single shared queue (not a per-replica one like
+     * {@link #CACHE_INVALIDATE_EXCHANGE}'s consumers): Redis is the one cross-proxy source of
+     * truth, so each event must be processed exactly once, not by every backend replica.
+     */
+    public static final String REDIS_SYNC_QUEUE = "blackhole.redis.sync";
+
     private RabbitTopology() {
         throw new UnsupportedOperationException("This class cannot be instantiated");
     }

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/PunishmentApplicationService.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/PunishmentApplicationService.java
@@ -119,12 +119,75 @@ public class PunishmentApplicationService {
         if (isNewProfile) {
             this.eventPublisher.publish("profile.created", Map.of("tenantId", tenantId.toString(), "owner", owner));
         }
-        this.eventPublisher.publish("punishment.created", Map.of(
+        Map<String, Object> punishmentCreatedPayload = new HashMap<>();
+        punishmentCreatedPayload.put("tenantId", tenantId.toString());
+        punishmentCreatedPayload.put("owner", owner);
+        punishmentCreatedPayload.put("punishmentIdentifier", savedPunishment.getIdentifier());
+        punishmentCreatedPayload.put("templateIdentifier", templateId.toString());
+        punishmentCreatedPayload.put("type", template.getType().toString());
+        if (metadata.containsKey(Expirable.META_DATA_KEY_EXPIRATION_DATE)) {
+            punishmentCreatedPayload.put("expiresAt", metadata.get(Expirable.META_DATA_KEY_EXPIRATION_DATE));
+        }
+        this.eventPublisher.publish("punishment.created", punishmentCreatedPayload);
+
+        return Optional.of(savedProfile);
+    }
+
+    /**
+     * Revokes {@code owner}'s active ban (SERVER or NETWORK), if any.
+     *
+     * @return the updated profile, or empty if the profile doesn't exist or has no active ban
+     */
+    public Optional<PunishmentProfileEntity> revokeBan(UUID tenantId, String owner, UUID revokedBy) {
+        return revoke(tenantId, owner, revokedBy, true);
+    }
+
+    /**
+     * Revokes {@code owner}'s active chat ban, if any.
+     *
+     * @return the updated profile, or empty if the profile doesn't exist or has no active mute
+     */
+    public Optional<PunishmentProfileEntity> revokeMute(UUID tenantId, String owner, UUID revokedBy) {
+        return revoke(tenantId, owner, revokedBy, false);
+    }
+
+    /**
+     * A deliberately independent 4th implementation of the "move active punishment into history"
+     * rotation already present in {@link #apply}, {@code PunishmentExpirySweeper.sweepProfile}
+     * and {@code AppealDecisionService.applyDecision} - not a refactor of those, to avoid
+     * regression risk in already-working code.
+     */
+    private Optional<PunishmentProfileEntity> revoke(UUID tenantId, String owner, UUID revokedBy, boolean banSlot) {
+        PunishmentProfileId profileId = new PunishmentProfileId(tenantId, owner);
+        PunishmentProfileEntity profile = this.profileRepository.findById(profileId).orElse(null);
+        if (profile == null) {
+            return Optional.empty();
+        }
+
+        PunishmentEntity active = banSlot ? profile.getActiveBan() : profile.getActiveChatBan();
+        if (active == null) {
+            return Optional.empty();
+        }
+
+        active.getMetaData().put("revokedBy", revokedBy.toString());
+        active.getMetaData().put(Metadata.META_DATA_KEY_UPDATE_DATE, System.currentTimeMillis());
+        this.punishmentRepository.update(active);
+
+        profile.getHistory().add(active);
+        if (banSlot) {
+            profile.setActiveBan(null);
+        } else {
+            profile.setActiveChatBan(null);
+        }
+        PunishmentProfileEntity savedProfile = this.profileRepository.update(profile);
+
+        this.cacheInvalidationPublisher.invalidate(tenantId, owner);
+        this.eventPublisher.publish("punishment.revoked", Map.of(
                 "tenantId", tenantId.toString(),
                 "owner", owner,
-                "punishmentIdentifier", savedPunishment.getIdentifier(),
-                "templateIdentifier", templateId.toString(),
-                "type", template.getType().toString()
+                "punishmentIdentifier", active.getIdentifier(),
+                "type", active.getType().toString(),
+                "revokedBy", revokedBy.toString()
         ));
 
         return Optional.of(savedProfile);

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/redis/PunishmentRedisWriter.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/redis/PunishmentRedisWriter.java
@@ -1,0 +1,85 @@
+package net.onelitefeather.blackhole.backend.redis;
+
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.micronaut.json.JsonMapper;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+
+/**
+ * The sole writer of active-punishment state into Redis. Called only from {@link RedisSyncConsumer}
+ * as a side effect of a domain event, never from a request thread - so a Redis hiccup here can
+ * never fail the primary write path that triggered it, matching
+ * {@code CacheInvalidationPublisher}'s resilience convention.
+ */
+@Singleton
+public class PunishmentRedisWriter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PunishmentRedisWriter.class);
+    private static final String SLOT_BAN = "BAN";
+    private static final String SLOT_CHAT_BAN = "CHAT_BAN";
+
+    private final StatefulRedisConnection<String, String> connection;
+    private final JsonMapper jsonMapper;
+
+    public PunishmentRedisWriter(StatefulRedisConnection<String, String> connection, JsonMapper jsonMapper) {
+        this.connection = connection;
+        this.jsonMapper = jsonMapper;
+    }
+
+    public void setBan(UUID tenantId, String owner, String type, String punishmentIdentifier, String templateIdentifier, Long expiresAt) {
+        set(RedisTopology.banKey(tenantId, owner), new PunishmentSyncMessage(
+                tenantId, owner, SLOT_BAN, "SET", type, punishmentIdentifier, templateIdentifier, expiresAt
+        ), expiresAt);
+    }
+
+    public void clearBan(UUID tenantId, String owner, String type, String punishmentIdentifier) {
+        clear(RedisTopology.banKey(tenantId, owner), new PunishmentSyncMessage(
+                tenantId, owner, SLOT_BAN, "CLEARED", type, punishmentIdentifier, null, null
+        ));
+    }
+
+    public void setChatBan(UUID tenantId, String owner, String punishmentIdentifier, String templateIdentifier, Long expiresAt) {
+        set(RedisTopology.chatBanKey(tenantId, owner), new PunishmentSyncMessage(
+                tenantId, owner, SLOT_CHAT_BAN, "SET", "CHAT", punishmentIdentifier, templateIdentifier, expiresAt
+        ), expiresAt);
+    }
+
+    public void clearChatBan(UUID tenantId, String owner, String punishmentIdentifier) {
+        clear(RedisTopology.chatBanKey(tenantId, owner), new PunishmentSyncMessage(
+                tenantId, owner, SLOT_CHAT_BAN, "CLEARED", "CHAT", punishmentIdentifier, null, null
+        ));
+    }
+
+    private void set(String key, PunishmentSyncMessage message, Long expiresAt) {
+        try {
+            String json = this.jsonMapper.writeValueAsString(message);
+            if (expiresAt != null) {
+                long ttlMillis = expiresAt - System.currentTimeMillis();
+                if (ttlMillis > 0) {
+                    this.connection.sync().psetex(key, ttlMillis, json);
+                } else {
+                    // Already expired by the time this event was processed - don't resurrect it.
+                    this.connection.sync().del(key);
+                }
+            } else {
+                this.connection.sync().set(key, json);
+            }
+            this.connection.sync().publish(RedisTopology.PUNISHMENT_SYNC_CHANNEL, json);
+        } catch (Exception e) {
+            LOGGER.error("Failed to write Redis punishment cache for key {}: {}", key, e.getMessage());
+        }
+    }
+
+    private void clear(String key, PunishmentSyncMessage message) {
+        try {
+            this.connection.sync().del(key);
+            String json = this.jsonMapper.writeValueAsString(message);
+            this.connection.sync().publish(RedisTopology.PUNISHMENT_SYNC_CHANNEL, json);
+        } catch (Exception e) {
+            LOGGER.error("Failed to clear Redis punishment cache for key {}: {}", key, e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/redis/PunishmentSyncMessage.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/redis/PunishmentSyncMessage.java
@@ -1,0 +1,35 @@
+package net.onelitefeather.blackhole.backend.redis;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+import java.util.UUID;
+
+/**
+ * Wire format published on {@link RedisTopology#PUNISHMENT_SYNC_CHANNEL} and stored as the value
+ * of the per-profile Redis key so a proxy's login-time {@code GET} carries the same data a
+ * pub/sub delta would. Hand-shared with Velocity's mirror record - deliberately not part of the
+ * OpenAPI client, since this is an internal side channel between the backend and proxies, not a
+ * public API contract.
+ *
+ * @param slot                  {@code BAN} or {@code CHAT_BAN} - which of
+ *                              {@code PunishmentProfileEntity}'s two active-punishment fields
+ *                              this message concerns
+ * @param state                 {@code SET} (a punishment is now active in this slot) or
+ *                              {@code CLEARED} (expired/revoked/appeal-lifted)
+ * @param type                  the {@code PunishType} the active punishment was applied as
+ *                              (SERVER/NETWORK/CHAT), null when {@code state == CLEARED} and the
+ *                              type isn't known
+ * @param expiresAt             epoch millis the punishment expires at, or null for a permanent
+ *                              punishment / a CLEARED message
+ */
+@Serdeable
+public record PunishmentSyncMessage(
+        UUID tenantId,
+        String owner,
+        String slot,
+        String state,
+        String type,
+        String punishmentIdentifier,
+        String templateIdentifier,
+        Long expiresAt
+) {}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/redis/RedisSyncConsumer.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/redis/RedisSyncConsumer.java
@@ -1,0 +1,122 @@
+package net.onelitefeather.blackhole.backend.redis;
+
+import com.rabbitmq.client.Channel;
+import io.micronaut.json.JsonMapper;
+import io.micronaut.rabbitmq.connect.ChannelPool;
+import io.micronaut.runtime.event.ApplicationStartupEvent;
+import io.micronaut.runtime.event.annotation.EventListener;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import net.onelitefeather.blackhole.backend.events.DomainEvent;
+import net.onelitefeather.blackhole.backend.events.RabbitTopology;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Mirrors active-punishment state into Redis so every Velocity proxy in a multi-proxy network
+ * sees consistent ban/mute state without querying the backend on every login/chat message.
+ * Consumes {@code punishment.created}/{@code expired}/{@code revoked} and
+ * {@code appeal.resolved} off the shared {@link RabbitTopology#REDIS_SYNC_QUEUE} - a shared
+ * (not per-replica) queue, since Redis is the one cross-proxy source of truth and each event
+ * must be processed exactly once.
+ *
+ * <p>Uses the raw RabbitMQ Java client (not {@code @RabbitListener}), same as
+ * {@code WebhookDispatchConsumer}. Unlike that consumer, this is an explicitly best-effort side
+ * channel with no retry loop: a missed write self-heals at the next mutation on the same
+ * profile, and every proxy falls back to an HTTP call on a cache miss, so a message is always
+ * acked after a single attempt rather than redelivered.</p>
+ */
+@Singleton
+public class RedisSyncConsumer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedisSyncConsumer.class);
+
+    private final ChannelPool channelPool;
+    private final JsonMapper jsonMapper;
+    private final PunishmentRedisWriter redisWriter;
+
+    public RedisSyncConsumer(@Named("default") ChannelPool channelPool, JsonMapper jsonMapper, PunishmentRedisWriter redisWriter) {
+        this.channelPool = channelPool;
+        this.jsonMapper = jsonMapper;
+        this.redisWriter = redisWriter;
+    }
+
+    @EventListener
+    void onStartup(ApplicationStartupEvent event) {
+        try {
+            Channel channel = this.channelPool.getChannel();
+            channel.basicConsume(RabbitTopology.REDIS_SYNC_QUEUE, false, (consumerTag, delivery) -> {
+                long deliveryTag = delivery.getEnvelope().getDeliveryTag();
+                try {
+                    handle(delivery.getBody());
+                } catch (Exception e) {
+                    LOGGER.error("Failed to process domain event for Redis sync: {}", e.getMessage());
+                }
+                channel.basicAck(deliveryTag, false);
+            }, consumerTag -> {
+                // no-op cancel callback
+            });
+            LOGGER.info("Listening for domain events to sync active punishment state into Redis");
+        } catch (IOException e) {
+            LOGGER.error("Failed to set up Redis sync consumer: {}", e.getMessage());
+        }
+    }
+
+    private void handle(byte[] body) throws IOException {
+        DomainEvent event = this.jsonMapper.readValue(body, DomainEvent.class);
+        Map<String, Object> payload = event.payload();
+        UUID tenantId = UUID.fromString(String.valueOf(payload.get("tenantId")));
+        String owner = String.valueOf(payload.get("owner"));
+        String punishmentIdentifier = stringOrNull(payload.get("punishmentIdentifier"));
+
+        switch (event.eventType()) {
+            case "punishment.created" -> {
+                String type = String.valueOf(payload.get("type"));
+                String templateIdentifier = stringOrNull(payload.get("templateIdentifier"));
+                Long expiresAt = asLong(payload.get("expiresAt"));
+                if ("CHAT".equals(type)) {
+                    this.redisWriter.setChatBan(tenantId, owner, punishmentIdentifier, templateIdentifier, expiresAt);
+                } else {
+                    this.redisWriter.setBan(tenantId, owner, type, punishmentIdentifier, templateIdentifier, expiresAt);
+                }
+            }
+            case "punishment.expired", "punishment.revoked" -> clearSlot(tenantId, owner, String.valueOf(payload.get("type")), punishmentIdentifier);
+            case "appeal.resolved" -> {
+                if ("GRANTED_FULL_LIFT".equals(String.valueOf(payload.get("decision")))) {
+                    clearSlot(tenantId, owner, String.valueOf(payload.get("type")), punishmentIdentifier);
+                }
+            }
+            default -> LOGGER.debug("Ignoring unrelated event type {} on the Redis sync queue", event.eventType());
+        }
+    }
+
+    private void clearSlot(UUID tenantId, String owner, String type, String punishmentIdentifier) {
+        if ("CHAT".equals(type)) {
+            this.redisWriter.clearChatBan(tenantId, owner, punishmentIdentifier);
+        } else {
+            this.redisWriter.clearBan(tenantId, owner, type, punishmentIdentifier);
+        }
+    }
+
+    private static String stringOrNull(Object value) {
+        return value == null ? null : value.toString();
+    }
+
+    private static Long asLong(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        try {
+            return Long.parseLong(value.toString());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/redis/RedisTopology.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/redis/RedisTopology.java
@@ -1,0 +1,26 @@
+package net.onelitefeather.blackhole.backend.redis;
+
+import java.util.UUID;
+
+/**
+ * Well-known Redis channel/key names shared between {@link PunishmentRedisWriter} and every
+ * Velocity proxy's read-side mirror - the key/channel format here must be replicated
+ * byte-for-byte on the Velocity side.
+ */
+public final class RedisTopology {
+
+    /** Pub/Sub channel carrying every {@link PunishmentSyncMessage} delta. */
+    public static final String PUNISHMENT_SYNC_CHANNEL = "blackhole.punishment.sync";
+
+    public static String banKey(UUID tenantId, String owner) {
+        return "blackhole:punish:ban:" + tenantId + ":" + owner;
+    }
+
+    public static String chatBanKey(UUID tenantId, String owner) {
+        return "blackhole:punish:chatban:" + tenantId + ":" + owner;
+    }
+
+    private RedisTopology() {
+        throw new UnsupportedOperationException("This class cannot be instantiated");
+    }
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/scheduling/PunishmentExpirySweeper.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/scheduling/PunishmentExpirySweeper.java
@@ -90,7 +90,8 @@ public class PunishmentExpirySweeper {
         this.eventPublisher.publish("punishment.expired", Map.of(
                 "tenantId", profile.getTenantId().toString(),
                 "owner", profile.getOwner(),
-                "punishmentIdentifier", expired.getIdentifier()
+                "punishmentIdentifier", expired.getIdentifier(),
+                "type", expired.getType().toString()
         ));
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -9,6 +9,13 @@ rabbitmq:
   username: ${RABBITMQ_USER:guest}
   password: ${RABBITMQ_PASSWORD:guest}
 
+# Redis mirrors active-punishment state for Velocity proxies (net.onelitefeather.blackhole.backend.redis)
+# - RedisSyncConsumer is the sole writer, bridging the domain event bus (punishment.created/
+# expired/revoked, appeal.resolved) onto Redis keys + a pub/sub channel so every proxy in a
+# multi-proxy network sees the same state without hitting this API on every login/chat message.
+redis:
+  uri: ${REDIS_URI:`redis://localhost:6379`}
+
 # Datasource
 datasources:
   default:

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 openApiGenerate {
     generatorName.set("java")
     library.set("native")
-    inputSpec.set("$projectDir/specs/blackhole-api-0.0.3.yml")
+    inputSpec.set("$projectDir/specs/blackhole-api-0.0.4.yml")
     outputDir.set(outDir.get().asFile.absolutePath)
     apiPackage.set("net.onelitefeather.blackhole.client.api")
     invokerPackage.set("net.onelitefeather.blackhole.client.invoker")

--- a/client/specs/blackhole-api-0.0.4.yml
+++ b/client/specs/blackhole-api-0.0.4.yml
@@ -1,0 +1,2012 @@
+openapi: 3.0.1
+info:
+  title: Blackhole API
+  description: Simple ban management system
+  contact:
+    name: Management
+    url: https://onelitefeather.net
+    email: admin@onelitefeather.net
+  license:
+    name: Close Source
+  version: 0.0.4
+paths:
+  /v1/appeal:
+    get:
+      tags:
+      - Appeal
+      summary: Get all appeals
+      description: Retrieves a paginated list of appeals for the caller's tenant
+      operationId: getAppeals
+      parameters:
+      - name: pageable
+        in: query
+        required: true
+        explode: false
+        schema:
+          $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          description: Successfully retrieved appeals
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AppealDTO"
+    post:
+      tags:
+      - Appeal
+      summary: Submit an appeal
+      description: Submits an appeal against a punishment. Immediately evaluated against
+        the eligibility checklist.
+      operationId: submitAppeal
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AppealSubmissionDTO"
+        required: true
+      responses:
+        "200":
+          description: Appeal submitted (status reflects whether it passed the eligibility
+            checklist)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppealDTO"
+        "404":
+          description: Punishment not found
+  /v1/appeal/{tenantId}/{identifier}/review:
+    post:
+      tags:
+      - Appeal
+      summary: Review an appeal
+      description: Decides an eligible appeal. Rejects self-review (reviewerId matching
+        the punishment's own source) and full lifts of SEVERE punishments (duration
+        reduction only).
+      operationId: reviewAppeal
+      parameters:
+      - name: tenantId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: identifier
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AppealReviewDTO"
+        required: true
+      responses:
+        "200":
+          description: Appeal decided
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppealDTO"
+        "404":
+          description: Appeal not found
+        "400":
+          description: "Invalid decision, or a full lift was attempted on a SEVERE\
+            \ punishment"
+        "403":
+          description: reviewerId matches the punishment's original source (self-review)
+        "409":
+          description: "Appeal is not awaiting review, or the punishment is no longer\
+            \ active"
+  /v1/auth/bootstrap:
+    post:
+      tags:
+      - Auth
+      summary: Bootstrap the first admin token
+      description: Exchanges the deployment's bootstrap secret for a PLATFORM_ADMIN
+        token.
+      operationId: bootstrap
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BootstrapRequestDTO"
+        required: true
+      responses:
+        "200":
+          description: bootstrap 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+  /v1/auth/token:
+    post:
+      tags:
+      - Auth
+      summary: Issue a tenant-scoped token
+      description: Issues a token for a given tenant and role. Requires an authenticated
+        PLATFORM_ADMIN or TENANT_ADMIN caller.
+      operationId: issueToken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IssueTokenRequestDTO"
+        required: true
+      responses:
+        "200":
+          description: issueToken 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+  /v1/connector:
+    get:
+      tags:
+      - Connector
+      summary: Get all connectors
+      operationId: getConnectors
+      parameters:
+      - name: pageable
+        in: query
+        required: true
+        explode: false
+        schema:
+          $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          description: getConnectors 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Page_ConnectorRegistrationDTO_"
+    post:
+      tags:
+      - Connector
+      summary: Register a connector
+      operationId: registerConnector
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectorRegistrationRequestDTO"
+        required: true
+      responses:
+        "200":
+          description: registerConnector 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorRegistrationCreatedDTO"
+  /v1/connector/oauth2/token:
+    post:
+      tags:
+      - Connector
+      summary: Exchange connector client credentials for a token
+      description: OAuth2 client-credentials style exchange. Returns a token scoped
+        to the connector's granted scopes.
+      operationId: connectorToken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectorTokenRequestDTO"
+        required: true
+      responses:
+        "200":
+          description: connectorToken 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+  /v1/connector/subscription:
+    post:
+      tags:
+      - Connector
+      summary: Create an event subscription for a connector
+      operationId: addEventSubscription
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EventSubscriptionRequestDTO"
+        required: true
+      responses:
+        "400":
+          description: deliveryUrl failed SSRF validation (see message)
+        "200":
+          description: addEventSubscription 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+  /v1/connector/subscription/{identifier}:
+    delete:
+      tags:
+      - Connector
+      summary: Delete an event subscription
+      operationId: removeEventSubscription
+      parameters:
+      - name: identifier
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: removeEventSubscription 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventSubscriptionDTO"
+  /v1/connector/{connectorId}/subscription:
+    get:
+      tags:
+      - Connector
+      summary: Get all event subscriptions for a connector
+      operationId: getEventSubscriptions
+      parameters:
+      - name: connectorId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: pageable
+        in: query
+        required: true
+        explode: false
+        schema:
+          $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          description: getEventSubscriptions 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Page_EventSubscriptionDTO_"
+  /v1/connector/{identifier}:
+    get:
+      tags:
+      - Connector
+      summary: Get a connector by ID
+      operationId: getConnectorById
+      parameters:
+      - name: identifier
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: getConnectorById 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorRegistrationDTO"
+    delete:
+      tags:
+      - Connector
+      summary: Delete a connector
+      operationId: removeConnector
+      parameters:
+      - name: identifier
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: removeConnector 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorRegistrationDTO"
+  /v1/connector/{identifier}/update:
+    post:
+      tags:
+      - Connector
+      summary: Update a connector's name/scopes/status
+      operationId: updateConnector
+      parameters:
+      - name: identifier
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectorRegistrationDTO"
+        required: true
+      responses:
+        "200":
+          description: updateConnector 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorRegistrationDTO"
+  /v1/elo/chat:
+    post:
+      tags:
+      - Elo
+      summary: Score a chat message for toxicity
+      description: "Scores a chat message; if flagged, records evidence (a hash, never\
+        \ the raw text) and applies a chat-ELO delta"
+      operationId: submitChatSignal
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChatSignalDTO"
+        required: true
+      responses:
+        "200":
+          description: Scoring result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChatToxicityResult"
+  /v1/elo/{tenantId}/{owner}:
+    get:
+      tags:
+      - Elo
+      summary: Get a player's current ELO standing
+      description: "Dashboard read endpoint: the current chat/gameplay scores"
+      operationId: getEloProfile
+      parameters:
+      - name: tenantId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: owner
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Current ELO profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EloProfileDTO"
+        "404":
+          description: No ELO profile exists yet for this owner
+  /v1/elo/{tenantId}/{owner}/history:
+    get:
+      tags:
+      - Elo
+      summary: Get a player's ELO history
+      description: "Dashboard read endpoint: the full audit trail of ELO changes for\
+        \ this owner"
+      operationId: getEloHistory
+      parameters:
+      - name: tenantId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: owner
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: pageable
+        in: query
+        required: true
+        explode: false
+        schema:
+          $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          description: Paginated ELO event history
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/EloEventDTO"
+  /v1/evasion/record:
+    post:
+      tags:
+      - Evasion
+      summary: Record a login sighting for ban-evasion detection
+      description: Computes a keyed hash of the IP (never stores it raw) and checks
+        whether multiple distinct owners share it recently
+      operationId: recordEvasionSighting
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EvasionRecordDTO"
+        required: true
+      responses:
+        "200":
+          description: Recorded
+          content:
+            application/json:
+              schema:
+                type: object
+        "503":
+          description: blackhole.evasion.ip-salt is not configured - evasion detection
+            is disabled
+  /v1/profile:
+    get:
+      tags:
+      - PunishProfile
+      summary: Get all punishment profiles.
+      description: Get all existing punishment profiles
+      operationId: getProfiles
+      parameters:
+      - name: pageable
+        in: query
+        required: true
+        explode: false
+        schema:
+          $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          description: The updated profile
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PunishProfileResponse"
+    post:
+      tags:
+      - PunishProfile
+      summary: Add a new punishment profile.
+      description: Add a new profile for punishments
+      operationId: addProfile
+      requestBody:
+        description: the profile to add
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PunishProfileDTO"
+        required: true
+      responses:
+        "200":
+          description: The profile which was added to the service
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishProfileResponse"
+  /v1/profile/delete/{tenantId}/{owner}:
+    delete:
+      tags:
+      - PunishProfile
+      summary: Delete a punishment profile by the owner.
+      description: Delete a punish profile via uuid
+      operationId: removeProfile
+      parameters:
+      - name: tenantId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: owner
+        in: path
+        description: the owner of the profile
+        required: true
+        schema:
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: Owner must be a sha-512 hash
+      responses:
+        "200":
+          description: The deleted profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishProfileResponse"
+        "400":
+          description: Error message when there is no profile linked to the given
+            id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /v1/profile/update/{tenantId}/{owner}:
+    post:
+      tags:
+      - PunishProfile
+      summary: Get a punishment profile by the owner.
+      description: Update a punishment profile
+      operationId: updateProfile
+      parameters:
+      - name: tenantId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: owner
+        in: path
+        required: true
+        schema:
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: Owner must be a sha-512 hash
+      requestBody:
+        description: the profile to get
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PunishProfileDTO"
+        required: true
+      responses:
+        "200":
+          description: The updated profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishProfileResponse"
+        "400":
+          description: Error message when there is no profile linked to the given
+            id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /v1/profile/{tenantId}/{owner}:
+    get:
+      tags:
+      - PunishProfile
+      summary: Get a punishment profile by the owner.
+      description: Get a profile by id
+      operationId: getById
+      parameters:
+      - name: tenantId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: owner
+        in: path
+        required: true
+        schema:
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: Owner must be a sha-512 hash
+      responses:
+        "200":
+          description: The profile which matches with the given id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishProfileDTO"
+        "404":
+          description: Error message when there is no profile linked to the given
+            id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /v1/profile/{tenantId}/{owner}/session:
+    post:
+      tags:
+      - PunishProfile
+      summary: "Records session telemetry (Phase 7's dashboard enrichment: Java/Bedrock\
+        \ protocol version and client brand) into the profile's existing metaData,\
+        \ so the already-existing profile listing/get endpoints surface it without\
+        \ a separate dashboard endpoint."
+      description: Records session telemetry (protocol version / client brand) for
+        the dashboard
+      operationId: updateSessionInfo
+      parameters:
+      - name: tenantId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: owner
+        in: path
+        required: true
+        schema:
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: Owner must be a sha-512 hash
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SessionInfoDTO"
+        required: true
+      responses:
+        "200":
+          description: Session info recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishProfileResponse"
+  /v1/punishment:
+    get:
+      tags:
+      - Punishment
+      summary: Get all punishments
+      description: Retrieves a paginated list of all punishment entries in the system
+      operationId: getPunishments
+      parameters:
+      - name: pageable
+        in: query
+        required: true
+        explode: false
+        schema:
+          $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          description: Successfully retrieved punishment entries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PunishEntryDTO"
+  /v1/punishment/active/{tenantId}/{owner}/ban/revoke/{source}:
+    post:
+      tags:
+      - Punishment
+      summary: Revoke active ban
+      description: "Revokes a player's active ban (SERVER or NETWORK), moving it into\
+        \ history"
+      operationId: revokeBan
+      parameters:
+      - name: tenantId
+        in: path
+        description: the tenant the punishment belongs to
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: owner
+        in: path
+        description: the owner of the punishment
+        required: true
+        schema:
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: Owner must be a sha-512 hash
+      - name: source
+        in: path
+        description: the staff/system identity revoking the punishment
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Ban successfully revoked
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishProfileResponse"
+        "404":
+          description: "Profile not found, or has no active ban"
+        "400":
+          description: Invalid input parameters (owner must be SHA-512 hash)
+  /v1/punishment/active/{tenantId}/{owner}/mute/revoke/{source}:
+    post:
+      tags:
+      - Punishment
+      summary: Revoke active mute
+      description: "Revokes a player's active chat ban, moving it into history"
+      operationId: revokeMute
+      parameters:
+      - name: tenantId
+        in: path
+        description: the tenant the punishment belongs to
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: owner
+        in: path
+        description: the owner of the punishment
+        required: true
+        schema:
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: Owner must be a sha-512 hash
+      - name: source
+        in: path
+        description: the staff/system identity revoking the punishment
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Mute successfully revoked
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishProfileResponse"
+        "404":
+          description: "Profile not found, or has no active mute"
+        "400":
+          description: Invalid input parameters (owner must be SHA-512 hash)
+  /v1/punishment/active/{tenantId}/{owner}/{templateId}/{source}:
+    post:
+      tags:
+      - Punishment
+      summary: Add active punishment
+      description: Creates and applies an active punishment to a player profile based
+        on a punishment template
+      operationId: addActivePunishment
+      parameters:
+      - name: tenantId
+        in: path
+        description: the tenant the punishment belongs to
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: owner
+        in: path
+        description: the owner of the punishment
+        required: true
+        schema:
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: Owner must be a sha-512 hash
+      - name: templateId
+        in: path
+        description: the template id of the punishment
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: source
+        in: path
+        description: the source of the punishment
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Punishment successfully applied to profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishProfileResponse"
+        "404":
+          description: Profile or template not found
+        "400":
+          description: Invalid input parameters (owner must be SHA-512 hash)
+  /v1/report:
+    get:
+      tags:
+      - Report
+      summary: Get all reports
+      description: Retrieves a paginated list of reports for the caller's tenant
+      operationId: getReports
+      parameters:
+      - name: pageable
+        in: query
+        required: true
+        explode: false
+        schema:
+          $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          description: Successfully retrieved reports
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ReportDTO"
+    post:
+      tags:
+      - Report
+      summary: Submit a report
+      description: Submits a player report. Rate-limited per reporterHash within a
+        configurable time window.
+      operationId: submitReport
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReportDTO"
+        required: true
+      responses:
+        "200":
+          description: Report successfully submitted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReportDTO"
+        "429":
+          description: Rate limit exceeded for this reporter
+  /v1/report/{tenantId}/{identifier}/resolve:
+    post:
+      tags:
+      - Report
+      summary: Resolve a report
+      description: "Resolves a report, optionally applying a punishment template to\
+        \ the reported player"
+      operationId: resolveReport
+      parameters:
+      - name: tenantId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: identifier
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReportResolutionDTO"
+        required: true
+      responses:
+        "200":
+          description: Report successfully resolved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReportDTO"
+        "404":
+          description: Report or punishment template not found
+        "400":
+          description: punishmentSource is required when punishmentTemplateId is set
+  /v1/signal:
+    post:
+      tags:
+      - Signal
+      summary: Submit an external signal
+      operationId: submitSignal
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SignalDTO"
+        required: true
+      responses:
+        "200":
+          description: submitSignal 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+  /v1/template:
+    get:
+      tags:
+      - Punishment Templates
+      summary: Get all punishment templates
+      description: Retrieves a paginated list of all punishment templates in the system
+      operationId: getAllTemplates
+      parameters:
+      - name: pageable
+        in: query
+        required: true
+        explode: false
+        schema:
+          $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          description: Successfully retrieved punishment templates
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PunishTemplateDTO"
+    post:
+      tags:
+      - Punishment Templates
+      summary: Create punishment template
+      description: Creates a new punishment template.
+      operationId: addTemplate
+      requestBody:
+        description: the template to add
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PunishTemplateDTO"
+        required: true
+      responses:
+        "200":
+          description: Template successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishTemplateDTO"
+        "405":
+          description: Method not allowed - identifier must be null for creation
+        "400":
+          description: Invalid template data
+  /v1/template/delete/{identifier}:
+    delete:
+      tags:
+      - Punishment Templates
+      summary: Delete punishment template
+      description: Deletes a punishment template by its identifier
+      operationId: deleteTemplate
+      parameters:
+      - name: identifier
+        in: path
+        description: the identifier of the template to remove
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Template successfully deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishTemplateDTO"
+        "404":
+          description: Template not found
+  /v1/template/update:
+    post:
+      tags:
+      - Punishment Templates
+      summary: Update punishment template
+      description: Updates an existing punishment template.
+      operationId: updateTemplate
+      requestBody:
+        description: the template to update
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PunishTemplateDTO"
+        required: true
+      responses:
+        "200":
+          description: Template successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishTemplateDTO"
+        "404":
+          description: Template not found
+        "400":
+          description: Invalid template data
+  /v1/template/{identifier}:
+    get:
+      tags:
+      - Punishment Templates
+      summary: Get punishment template by ID
+      description: Retrieves a specific punishment template by its identifier
+      operationId: getTemplateById
+      parameters:
+      - name: identifier
+        in: path
+        description: the identifier of the template to retrieve
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Template successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishTemplateDTO"
+        "404":
+          description: Template not found
+  /v1/tenant:
+    get:
+      tags:
+      - Tenants
+      summary: Get all tenants
+      description: Retrieves a paginated list of all tenants in the system
+      operationId: getTenants
+      parameters:
+      - name: pageable
+        in: query
+        required: true
+        explode: false
+        schema:
+          $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          description: Successfully retrieved tenants
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TenantDTO"
+    post:
+      tags:
+      - Tenants
+      summary: Create tenant
+      description: Creates a new tenant.
+      operationId: addTenant
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TenantDTO"
+        required: true
+      responses:
+        "200":
+          description: Tenant successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TenantDTO"
+        "405":
+          description: Method not allowed - identifier must be null for creation
+        "409":
+          description: A tenant with this slug already exists
+  /v1/tenant/delete/{identifier}:
+    delete:
+      tags:
+      - Tenants
+      summary: Delete tenant
+      description: Deletes a tenant by its identifier
+      operationId: deleteTenant
+      parameters:
+      - name: identifier
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Tenant successfully deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TenantDTO"
+        "404":
+          description: Tenant not found
+  /v1/tenant/update:
+    post:
+      tags:
+      - Tenants
+      summary: Update tenant
+      description: Updates an existing tenant.
+      operationId: updateTenant
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TenantDTO"
+        required: true
+      responses:
+        "200":
+          description: Tenant successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TenantDTO"
+        "404":
+          description: Tenant not found
+  /v1/tenant/{identifier}:
+    get:
+      tags:
+      - Tenants
+      summary: Get tenant by ID
+      description: Retrieves a specific tenant by its identifier
+      operationId: getTenantById
+      parameters:
+      - name: identifier
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Tenant successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TenantDTO"
+        "404":
+          description: Tenant not found
+components:
+  schemas:
+    AppealDTO:
+      required:
+      - appellantHash
+      - createdAt
+      - eligibilityCheckResult
+      - identifier
+      - metaData
+      - punishmentIdentifier
+      - statement
+      - status
+      - tenantId
+      - updatedAt
+      type: object
+      properties:
+        identifier:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        punishmentIdentifier:
+          type: string
+        appellantHash:
+          type: string
+        statement:
+          type: string
+        status:
+          $ref: "#/components/schemas/AppealStatus"
+        eligibilityCheckResult:
+          type: object
+          additionalProperties:
+            type: object
+        decidedBy:
+          type: string
+          format: uuid
+          nullable: true
+        decisionNote:
+          type: string
+          nullable: true
+        createdAt:
+          type: integer
+          format: int64
+        updatedAt:
+          type: integer
+          format: int64
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+    AppealReviewDTO:
+      required:
+      - decision
+      - reviewerId
+      type: object
+      properties:
+        decision:
+          $ref: "#/components/schemas/AppealStatus"
+        decisionNote:
+          maxLength: 2000
+          type: string
+          description: an optional note explaining the decision
+          nullable: true
+        reviewerId:
+          type: string
+          description: the staff/system identity making this decision; rejected if
+            it matches the punishment's own `source` (self-review exclusion)
+          format: uuid
+        newExpirationAt:
+          type: integer
+          description: "required when `decision` is `GRANTED_DURATION_REDUCTION` -\
+            \ the new, sooner expiration timestamp (epoch millis)"
+          format: int64
+          nullable: true
+    AppealStatus:
+      type: string
+      description: The lifecycle state of an appeal.
+      enum:
+      - SUBMITTED
+      - ELIGIBLE_PENDING_REVIEW
+      - IN_REVIEW
+      - GRANTED_FULL_LIFT
+      - GRANTED_DURATION_REDUCTION
+      - DENIED
+      - INELIGIBLE
+    AppealSubmissionDTO:
+      required:
+      - appellantHash
+      - punishmentIdentifier
+      - statement
+      - tenantId
+      type: object
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        punishmentIdentifier:
+          minLength: 1
+          type: string
+        appellantHash:
+          minLength: 1
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: appellantHash must be a sha-512 hash
+        statement:
+          maxLength: 2000
+          minLength: 1
+          type: string
+    BootstrapRequestDTO:
+      required:
+      - secret
+      type: object
+      properties:
+        secret:
+          minLength: 1
+          type: string
+    ChatSignalDTO:
+      required:
+      - message
+      - owner
+      - tenantId
+      type: object
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        owner:
+          minLength: 1
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: owner must be a sha-512 hash
+        message:
+          maxLength: 512
+          minLength: 1
+          type: string
+    ChatToxicityResult:
+      required:
+      - flagged
+      - score
+      type: object
+      properties:
+        flagged:
+          type: boolean
+        score:
+          type: number
+          format: double
+    ConnectorRegistrationCreatedDTO:
+      required:
+      - connector
+      - oauth2ClientSecret
+      type: object
+      properties:
+        connector:
+          $ref: "#/components/schemas/ConnectorRegistrationDTO"
+        oauth2ClientSecret:
+          type: string
+      description: Response to a connector registration. `oauth2ClientSecret` is the
+        only time the plaintext secret is ever shown - only the SHA-512 hash is persisted.
+    ConnectorRegistrationDTO:
+      required:
+      - identifier
+      - metaData
+      - name
+      - oauth2ClientId
+      - scopes
+      - status
+      - tenantId
+      type: object
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        identifier:
+          type: string
+          format: uuid
+        name:
+          type: string
+        oauth2ClientId:
+          type: string
+        scopes:
+          type: array
+          items:
+            type: string
+        status:
+          $ref: "#/components/schemas/ConnectorStatus"
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+      description: "Representation of a registered connector. Deliberately never carries\
+        \ the client secret (or its hash) - that's only ever shown once, at creation\
+        \ time, via ConnectorRegistrationCreatedDTO."
+    ConnectorRegistrationRequestDTO:
+      required:
+      - name
+      - scopes
+      - tenantId
+      type: object
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        name:
+          minLength: 1
+          type: string
+        scopes:
+          minItems: 1
+          type: array
+          items:
+            type: string
+    ConnectorStatus:
+      type: string
+      description: Whether a registered connector may currently authenticate/receive
+        webhook deliveries.
+      enum:
+      - ACTIVE
+      - SUSPENDED
+    ConnectorTokenRequestDTO:
+      required:
+      - clientId
+      - clientSecret
+      type: object
+      properties:
+        clientId:
+          minLength: 1
+          type: string
+        clientSecret:
+          minLength: 1
+          type: string
+      description: OAuth2 client-credentials style exchange for a connector-scoped
+        token.
+    EloEventDTO:
+      required:
+      - createdAt
+      - delta
+      - identifier
+      - metaData
+      - owner
+      - reasonCode
+      - resultingScore
+      - tenantId
+      - track
+      type: object
+      properties:
+        identifier:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        owner:
+          type: string
+        track:
+          $ref: "#/components/schemas/EloTrack"
+        delta:
+          type: integer
+          format: int32
+        reasonCode:
+          $ref: "#/components/schemas/EloReasonCode"
+        sourceEvidenceId:
+          type: string
+          format: uuid
+          nullable: true
+        resultingScore:
+          type: integer
+          format: int32
+        createdAt:
+          type: integer
+          format: int64
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+    EloProfileDTO:
+      required:
+      - chatElo
+      - chatEloUpdatedAt
+      - gameplayElo
+      - gameplayEloUpdatedAt
+      - metaData
+      - owner
+      - tenantId
+      type: object
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        owner:
+          type: string
+        chatElo:
+          type: integer
+          format: int32
+        gameplayElo:
+          type: integer
+          format: int32
+        chatEloUpdatedAt:
+          type: integer
+          format: int64
+        gameplayEloUpdatedAt:
+          type: integer
+          format: int64
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+    EloReasonCode:
+      type: string
+      description: Why an `EloEventEntity` happened. This is the audit trail that
+        lets a reviewer (or a future Phase 6 appeal) tell an algorithmic decision
+        apart from a human one.
+      enum:
+      - TOXICITY_FLAG
+      - ANTICHEAT_FLAG
+      - REPORT_ACTIONED
+      - MANUAL_ADJUSTMENT
+      - DECAY_RECOVERY
+      - THRESHOLD_BAN
+    EloTrack:
+      type: string
+      description: "The two independent ELO tracks. A player can play without chatting\
+        \ (or vice versa), so each track must be able to trigger consequences on its\
+        \ own - a silent cheater must be caught by the gameplay track even with zero\
+        \ chat activity, and a toxic-but-legitimate player must be caught by the chat\
+        \ track even with clean gameplay."
+      enum:
+      - CHAT
+      - GAMEPLAY
+    ErrorResponse:
+      type: object
+      properties:
+        The error message:
+          type: string
+          description: the error message
+      description: The error response when something went wrong on profile requests
+    EvasionRecordDTO:
+      required:
+      - ip
+      - owner
+      - tenantId
+      type: object
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        owner:
+          minLength: 1
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: owner must be a sha-512 hash
+        ip:
+          minLength: 1
+          type: string
+    EventSubscriptionDTO:
+      required:
+      - active
+      - connectorId
+      - deliveryUrl
+      - eventTypes
+      - failureCount
+      - identifier
+      - metaData
+      type: object
+      properties:
+        identifier:
+          type: string
+          format: uuid
+        connectorId:
+          type: string
+          format: uuid
+        eventTypes:
+          type: array
+          items:
+            type: string
+        deliveryUrl:
+          type: string
+        active:
+          type: boolean
+        failureCount:
+          type: integer
+          format: int32
+        lastAttemptAt:
+          type: integer
+          format: int64
+          nullable: true
+        lastSuccessAt:
+          type: integer
+          format: int64
+          nullable: true
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+      description: "Representation of a connector's event subscription. Never carries\
+        \ the signing secret - that's only shown once, at creation time, via EventSubscriptionCreatedDTO."
+    EventSubscriptionRequestDTO:
+      required:
+      - connectorId
+      - deliveryUrl
+      - eventTypes
+      type: object
+      properties:
+        connectorId:
+          type: string
+          format: uuid
+        eventTypes:
+          minItems: 1
+          type: array
+          items:
+            type: string
+        deliveryUrl:
+          minLength: 1
+          type: string
+    IssueTokenRequestDTO:
+      required:
+      - role
+      - tenantId
+      type: object
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        role:
+          minLength: 1
+          type: string
+    Page_ConnectorRegistrationDTO_:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Slice_ConnectorRegistrationDTO_"
+      - type: object
+        properties:
+          totalSize:
+            type: integer
+            format: int64
+          totalPages:
+            type: integer
+            format: int32
+    Page_EventSubscriptionDTO_:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Slice_EventSubscriptionDTO_"
+      - type: object
+        properties:
+          totalSize:
+            type: integer
+            format: int64
+          totalPages:
+            type: integer
+            format: int32
+    Pageable:
+      required:
+      - size
+      - sort
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Sort"
+      - type: object
+        properties:
+          number:
+            type: integer
+            format: int32
+          size:
+            type: integer
+            format: int32
+          mode:
+            $ref: "#/components/schemas/Pageable.Mode"
+          sort:
+            $ref: "#/components/schemas/Sort"
+    Pageable.Mode:
+      type: string
+      enum:
+      - CURSOR_NEXT
+      - CURSOR_PREVIOUS
+      - OFFSET
+    PunishEntryDTO:
+      required:
+      - identifier
+      - metaData
+      - scope
+      - source
+      - template
+      - tenantId
+      - type
+      type: object
+      properties:
+        identifier:
+          type: string
+          description: the identifier of the punishment
+        tenantId:
+          type: string
+          description: the tenant the punishment belongs to
+          format: uuid
+        source:
+          type: string
+          description: the source of the punishment
+          format: uuid
+        type:
+          $ref: "#/components/schemas/PunishType"
+        scope:
+          type: string
+          description: "the optional scope (e.g. event/community) this punishment\
+            \ is restricted to, or `null` for network-wide"
+        template:
+          $ref: "#/components/schemas/PunishTemplateDTO"
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+          description: the metadata of the punishment
+      description: Represents a punish entry which can be used to store the punishment
+        in the database.
+    PunishProfileDTO:
+      required:
+      - metaData
+      - owner
+      - tenantId
+      type: object
+      properties:
+        activeChatBan:
+          nullable: true
+          allOf:
+          - $ref: "#/components/schemas/PunishEntryDTO"
+        activeBan:
+          nullable: true
+          allOf:
+          - $ref: "#/components/schemas/PunishEntryDTO"
+        tenantId:
+          type: string
+          format: uuid
+        owner:
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: Owner must be a sha-512 hash
+        history:
+          type: array
+          nullable: true
+          items:
+            $ref: "#/components/schemas/PunishEntryDTO"
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+    PunishProfileResponse:
+      type: object
+    PunishTemplateDTO:
+      required:
+      - metaData
+      - reason
+      - tenantId
+      - type
+      type: object
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+        reason:
+          minLength: 1
+          type: string
+        type:
+          $ref: "#/components/schemas/PunishType"
+        identifier:
+          type: string
+          format: uuid
+          nullable: true
+    PunishType:
+      type: string
+      description: |-
+        This enumeration defines each type of ban which is supported by the application.
+
+
+        The following types are supported:
+
+        * Server: means that a target is banned from a specific server
+        * Network: means that a target is banned from the whole network
+        * Chat: means that a target is banned from the chat
+      enum:
+      - SERVER
+      - NETWORK
+      - CHAT
+    ReportCategory:
+      type: string
+      description: What kind of behavior a report is about.
+      enum:
+      - CHAT_ABUSE
+      - CHEATING
+      - GRIEFING
+      - OTHER
+    ReportDTO:
+      required:
+      - category
+      - createdAt
+      - metaData
+      - reportedHash
+      - reporterHash
+      - tenantId
+      - updatedAt
+      type: object
+      properties:
+        tenantId:
+          type: string
+          description: the tenant this report belongs to
+          format: uuid
+        identifier:
+          type: string
+          description: "the identifier of the report, `null` when submitting"
+          format: uuid
+          nullable: true
+        reporterHash:
+          minLength: 1
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          description: SHA-512 hash of the reporting player
+          x-pattern-message: reporterHash must be a sha-512 hash
+        reportedHash:
+          minLength: 1
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          description: SHA-512 hash of the reported player
+          x-pattern-message: reportedHash must be a sha-512 hash
+        category:
+          $ref: "#/components/schemas/ReportCategory"
+        description:
+          maxLength: 1000
+          type: string
+          description: a bounded free-text description
+          nullable: true
+        evidenceReferences:
+          type: array
+          description: optional references to `PunishmentEvidenceEntity` entries
+          nullable: true
+          items:
+            type: string
+            format: uuid
+        status:
+          nullable: true
+          allOf:
+          - $ref: "#/components/schemas/ReportStatus"
+        createdAt:
+          type: integer
+          description: epoch millis when the report was submitted
+          format: int64
+        updatedAt:
+          type: integer
+          description: epoch millis of the last status change
+          format: int64
+        resolvedBy:
+          type: string
+          description: "the staff/system identity that resolved this report, if resolved"
+          format: uuid
+          nullable: true
+        resolutionNote:
+          maxLength: 1000
+          type: string
+          description: "a note explaining the resolution, if resolved"
+          nullable: true
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+          description: extensible metadata
+      description: "A player report. `status`/`createdAt`/`updatedAt`/`resolvedBy`/\
+        \ `resolutionNote` are server-controlled - a submission simply leaves them\
+        \ unset/default, the same nullable-identifier-means-create convention used\
+        \ by TenantDTO."
+    ReportResolutionDTO:
+      required:
+      - resolvedBy
+      - status
+      type: object
+      properties:
+        status:
+          $ref: "#/components/schemas/ReportStatus"
+        resolutionNote:
+          maxLength: 1000
+          type: string
+          description: an optional note explaining the decision
+          nullable: true
+        resolvedBy:
+          type: string
+          description: the staff/system identity resolving this report
+          format: uuid
+        punishmentTemplateId:
+          type: string
+          description: an optional template to apply to the reported player
+          format: uuid
+          nullable: true
+        punishmentSource:
+          type: string
+          description: the staff/system identity applying the punishment; required
+            if `punishmentTemplateId` is set
+          format: uuid
+          nullable: true
+      description: Request body for resolving a report. Providing `punishmentTemplateId`
+        (together with `punishmentSource`) applies that template to the reported player
+        as part of the same resolution - the report system's actual integration point
+        with punishments.
+    ReportStatus:
+      type: string
+      description: The lifecycle state of a report.
+      enum:
+      - OPEN
+      - UNDER_REVIEW
+      - ACTIONED
+      - DISMISSED
+    SessionInfoDTO:
+      required:
+      - owner
+      - tenantId
+      type: object
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        owner:
+          minLength: 1
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: owner must be a sha-512 hash
+        protocolVersion:
+          type: integer
+          format: int32
+          nullable: true
+        clientBrand:
+          maxLength: 64
+          type: string
+          nullable: true
+      description: "Session telemetry captured at login/brand-negotiation time (Phase\
+        \ 7's dashboard enrichment). Both fields are optional and merged, not overwritten,\
+        \ into the profile's existing session info - `protocolVersion` arrives at\
+        \ login, `clientBrand` arrives slightly later as a separate plugin-channel\
+        \ negotiation, so a single caller rarely has both at once."
+    SignalDTO:
+      required:
+      - metaData
+      - owner
+      - payload
+      - signalType
+      - tenantId
+      type: object
+      properties:
+        tenantId:
+          type: string
+          description: the tenant this signal belongs to
+          format: uuid
+        owner:
+          minLength: 1
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          description: SHA-512 hash of the affected player
+          x-pattern-message: owner must be a sha-512 hash
+        signalType:
+          minLength: 1
+          type: string
+          description: "a connector-chosen identifier, e.g. `anticheat.flag`"
+        payload:
+          type: object
+          additionalProperties:
+            type: object
+          description: signal-specific data
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+          description: extensible metadata
+      description: A generic external signal (e.g. an anticheat flag) ingested via
+        `POST /signal`. Deliberately opaque - Blackhole doesn't know or care what
+        `signalType` values a given connector uses; it's published as a domain event
+        and Phase 5's ELO system (or any other consumer) decides what to do with it.
+        This is what keeps the connector framework generic rather than anticheat-specific.
+    Slice_ConnectorRegistrationDTO_:
+      required:
+      - content
+      - pageable
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/ConnectorRegistrationDTO"
+        pageable:
+          $ref: "#/components/schemas/Pageable"
+        pageNumber:
+          type: integer
+          format: int32
+        offset:
+          type: integer
+          format: int64
+        size:
+          type: integer
+          format: int32
+        empty:
+          type: boolean
+        numberOfElements:
+          type: integer
+          format: int32
+    Slice_EventSubscriptionDTO_:
+      required:
+      - content
+      - pageable
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/EventSubscriptionDTO"
+        pageable:
+          $ref: "#/components/schemas/Pageable"
+        pageNumber:
+          type: integer
+          format: int32
+        offset:
+          type: integer
+          format: int64
+        size:
+          type: integer
+          format: int32
+        empty:
+          type: boolean
+        numberOfElements:
+          type: integer
+          format: int32
+    Sort:
+      required:
+      - orderBy
+      type: object
+      properties:
+        orderBy:
+          type: array
+          items:
+            $ref: "#/components/schemas/Sort.Order"
+    Sort.Order:
+      required:
+      - direction
+      - ignoreCase
+      - property
+      type: object
+      properties:
+        ignoreCase:
+          type: boolean
+        direction:
+          $ref: "#/components/schemas/Sort.Order.Direction"
+        property:
+          type: string
+        ascending:
+          type: boolean
+    Sort.Order.Direction:
+      type: string
+      enum:
+      - ASC
+      - DESC
+    TenantDTO:
+      required:
+      - metaData
+      - name
+      - slug
+      - status
+      type: object
+      properties:
+        identifier:
+          type: string
+          format: uuid
+          nullable: true
+        name:
+          minLength: 1
+          type: string
+        slug:
+          minLength: 1
+          type: string
+        status:
+          $ref: "#/components/schemas/TenantStatus"
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+    TenantStatus:
+      type: string
+      enum:
+      - ACTIVE
+      - SUSPENDED

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,6 +23,15 @@ services:
       - "5672:5672"
       - "15672:15672"
       - "15692:15692"
+  redis:
+    image: redis:7-alpine
+    container_name: 'redis_blackhole'
+    networks:
+      - blackhole_go_net
+    ports:
+      - "6379:6379"
+    volumes:
+      - ./redis/data/:/data
 
 networks:
   blackhole_go_net:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,6 +28,7 @@ dependencyResolutionManagement {
         create("libs") {
             version("micronaut", "5.0.2")
             version("velocity", "3.4.0")
+            version("lettuce", "6.8.1.RELEASE")
             version("cloud.commands", "2.0.0")
             version("shadow", "9.4.3")
             version("jetbrains.annotations", "26.1.0")
@@ -51,6 +52,9 @@ dependencyResolutionManagement {
             library("jakarta-annotation-api", "jakarta.annotation", "jakarta.annotation-api").versionRef("jakarta-annotation")
 
             library("velocity-api", "com.velocitypowered", "velocity-api").versionRef("velocity")
+            // Velocity is a plain Guice plugin, not a Micronaut app, so it talks to Redis via
+            // raw Lettuce rather than the Micronaut redis module the backend uses.
+            library("lettuce-core", "io.lettuce", "lettuce-core").versionRef("lettuce")
             library("cloud-velocity", "org.incendo", "cloud-velocity").version("2.0.0-SNAPSHOT")
             library("cloud-annotations", "org.incendo", "cloud-annotations").versionRef("cloud.commands")
             library("cloudExtras", "org.incendo", "cloud-minecraft-extras").version("2.0.0-SNAPSHOT")

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -14,6 +14,13 @@ dependencies {
 
     implementation(libs.cloud.annotations)
     implementation(libs.cloud.velocity)
+    implementation(libs.lettuce.core)
+
+    // client's jackson-databind is `implementation`-scoped there, so it isn't exposed
+    // transitively - needed here directly to (de)serialize RedisSyncService's wire messages.
+    implementation(platform(libs.jackson.bom))
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.databind)
 
     compileOnly(libs.velocity.api)
 

--- a/velocity/src/main/java/net/onelitefeather/blackhole/velocity/BlackholeVelocity.java
+++ b/velocity/src/main/java/net/onelitefeather/blackhole/velocity/BlackholeVelocity.java
@@ -7,12 +7,14 @@ import com.google.inject.TypeLiteral;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
 import net.onelitefeather.blackhole.client.invoker.ApiClient;
 import net.onelitefeather.blackhole.client.invoker.Configuration;
 import net.onelitefeather.blackhole.client.model.PunishType;
+import net.onelitefeather.blackhole.velocity.command.PardonCommand;
 import net.onelitefeather.blackhole.velocity.command.PunishCommand;
 import net.onelitefeather.blackhole.velocity.command.PunishInfoCommand;
 import net.onelitefeather.blackhole.velocity.command.PunishTypeScope;
@@ -21,6 +23,7 @@ import net.onelitefeather.blackhole.velocity.listener.PlayerChatListener;
 import net.onelitefeather.blackhole.velocity.listener.PlayerClientBrandListener;
 import net.onelitefeather.blackhole.velocity.listener.PlayerLoginListener;
 import net.onelitefeather.blackhole.velocity.module.BlackholeClientModule;
+import net.onelitefeather.blackhole.velocity.redis.RedisSyncService;
 import net.kyori.adventure.text.minimessage.translation.MiniMessageTranslationStore;
 import net.kyori.adventure.translation.GlobalTranslator;
 import org.incendo.cloud.SenderMapper;
@@ -50,6 +53,7 @@ public class BlackholeVelocity {
     private final Logger logger;
     private ApiClient client;
     private BlackholeConfig config;
+    private RedisSyncService redisSyncService;
 
 
     @Inject
@@ -72,7 +76,9 @@ public class BlackholeVelocity {
         }
         this.client.setRequestInterceptor(builder -> builder.header("Authorization", "Bearer " + this.config.getServiceToken()));
         this.logger.info("Initialized Blackhole client");
-        Injector childInjector = this.injector.createChildInjector(new BlackholeClientModule(this.client, this.config),  new CloudInjectionModule<>(
+        this.redisSyncService = new RedisSyncService(this.server, this.config, this.client);
+        this.redisSyncService.connect();
+        Injector childInjector = this.injector.createChildInjector(new BlackholeClientModule(this.client, this.config, this.redisSyncService),  new CloudInjectionModule<>(
                 CommandSource.class,
                 ExecutionCoordinator.simpleCoordinator(),
                 SenderMapper.identity()
@@ -88,9 +94,18 @@ public class BlackholeVelocity {
         );
         annotationParser.parse(childInjector.getInstance(PunishCommand.class));
         annotationParser.parse(childInjector.getInstance(PunishInfoCommand.class));
+        annotationParser.parse(childInjector.getInstance(PardonCommand.class));
         server.getEventManager().register(this, childInjector.getInstance(PlayerLoginListener.class));
         server.getEventManager().register(this, childInjector.getInstance(PlayerChatListener.class));
         server.getEventManager().register(this, childInjector.getInstance(PlayerClientBrandListener.class));
+        server.getEventManager().register(this, this.redisSyncService);
+    }
+
+    @Subscribe
+    public void onProxyShutdown(ProxyShutdownEvent event) {
+        if (this.redisSyncService != null) {
+            this.redisSyncService.shutdown();
+        }
     }
 
     private void registerTranslations() {

--- a/velocity/src/main/java/net/onelitefeather/blackhole/velocity/command/PardonCommand.java
+++ b/velocity/src/main/java/net/onelitefeather/blackhole/velocity/command/PardonCommand.java
@@ -1,0 +1,121 @@
+package net.onelitefeather.blackhole.velocity.command;
+
+import com.google.inject.Inject;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import net.kyori.adventure.text.Component;
+import net.onelitefeather.blackhole.client.api.PunishProfileApi;
+import net.onelitefeather.blackhole.client.api.PunishmentApi;
+import net.onelitefeather.blackhole.client.invoker.ApiClient;
+import net.onelitefeather.blackhole.client.invoker.ApiException;
+import net.onelitefeather.blackhole.client.model.PunishProfileDTO;
+import net.onelitefeather.blackhole.velocity.config.BlackholeConfig;
+import net.onelitefeather.blackhole.velocity.utils.UUIDConverter;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.CommandDescription;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotations.parser.Parser;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.context.CommandInput;
+import org.incendo.cloud.key.CloudKey;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+
+/**
+ * Reverses an active ban/mute. Unlike {@link PunishCommand}'s {@code profile} parser, a pardon
+ * target is typically offline (that's the whole point of unbanning them), so this command needs
+ * its own parser that doesn't require a live {@link Player} - see {@link #parseProfile}.
+ */
+public final class PardonCommand {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PardonCommand.class);
+    private static final CloudKey<String> DISPLAY_NAME_KEY = CloudKey.of("pardonDisplayName", String.class);
+
+    private final ProxyServer proxyServer;
+    private final PunishProfileApi punishProfileApi;
+    private final PunishmentApi punishmentApi;
+    private final BlackholeConfig config;
+
+    @Inject
+    public PardonCommand(@NotNull ProxyServer proxyServer, @NotNull ApiClient apiClient, @NotNull BlackholeConfig config) {
+        this.proxyServer = proxyServer;
+        this.punishProfileApi = new PunishProfileApi(apiClient);
+        this.punishmentApi = new PunishmentApi(apiClient);
+        this.config = config;
+    }
+
+    @Command("blackhole <user> unban")
+    @Command("unban <user>")
+    @Permission("blackhole.unban")
+    @CommandDescription("Revoke a player's active ban")
+    public void unbanPlayer(
+            CommandContext<Player> context,
+            @Argument(value = "user", parserName = "pardon-profile") @NotNull PunishProfileDTO user
+    ) {
+        if (user.getActiveBan() == null) {
+            context.sender().sendMessage(Component.translatable("punishment.error.unban.none_active"));
+            return;
+        }
+        try {
+            this.punishmentApi.revokeBan(this.config.getTenantId(), user.getOwner(), context.sender().getUniqueId());
+        } catch (ApiException e) {
+            LOGGER.error("Failed to unban player {}: {}", user.getOwner(), e.getMessage());
+            context.sender().sendMessage(Component.translatable("punishment.error.unban"));
+            return;
+        }
+        context.sender().sendMessage(Component.translatable("punishment.success.unban").arguments(Component.text(context.get(DISPLAY_NAME_KEY))));
+    }
+
+    @Command("blackhole <user> unmute")
+    @Command("unmute <user>")
+    @Permission("blackhole.unmute")
+    @CommandDescription("Revoke a player's active mute")
+    public void unmutePlayer(
+            CommandContext<Player> context,
+            @Argument(value = "user", parserName = "pardon-profile") @NotNull PunishProfileDTO user
+    ) {
+        if (user.getActiveChatBan() == null) {
+            context.sender().sendMessage(Component.translatable("punishment.error.unmute.none_active"));
+            return;
+        }
+        try {
+            this.punishmentApi.revokeMute(this.config.getTenantId(), user.getOwner(), context.sender().getUniqueId());
+        } catch (ApiException e) {
+            LOGGER.error("Failed to unmute player {}: {}", user.getOwner(), e.getMessage());
+            context.sender().sendMessage(Component.translatable("punishment.error.unmute"));
+            return;
+        }
+        context.sender().sendMessage(Component.translatable("punishment.success.unmute").arguments(Component.text(context.get(DISPLAY_NAME_KEY))));
+    }
+
+    @Parser(name = "pardon-profile")
+    public PunishProfileDTO parseProfile(CommandContext<CommandSource> context, CommandInput input) {
+        String name = input.readString();
+        context.store(DISPLAY_NAME_KEY, name);
+
+        String ownerHash = this.proxyServer.getPlayer(name)
+                .map(Player::getUniqueId)
+                .map(UUIDConverter::convertToSHA)
+                .orElseGet(() -> offlineOwnerHash(name));
+
+        try {
+            return this.punishProfileApi.getById(this.config.getTenantId(), ownerHash);
+        } catch (ApiException e) {
+            LOGGER.error("Failed to fetch punish profile for {}: {}", name, e.getMessage());
+            throw new IllegalArgumentException("No punishment profile found for %s".formatted(name));
+        }
+    }
+
+    private static String offlineOwnerHash(String name) {
+        try {
+            return UUIDConverter.convertToSHA(UUID.fromString(name));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Player(%s) is not online and is not a valid UUID".formatted(name));
+        }
+    }
+}

--- a/velocity/src/main/java/net/onelitefeather/blackhole/velocity/config/BlackholeConfig.java
+++ b/velocity/src/main/java/net/onelitefeather/blackhole/velocity/config/BlackholeConfig.java
@@ -31,12 +31,21 @@ public class BlackholeConfig {
     private String serviceToken;
 
     /**
+     * Redis connection used to read active-punishment state mirrored by the backend's
+     * RedisSyncConsumer, so a login/chat check on this proxy can hit a shared, fast cache
+     * instead of an HTTP call to the backend - and so a punishment applied on another proxy in
+     * the network is enforced here immediately via pub/sub, not just on this player's next login.
+     */
+    private String redisUri;
+
+    /**
      * Creates a new configuration with default values.
      */
     public BlackholeConfig() {
         this.baseUrl = "http://localhost:8080";
         this.tenantId = "00000000-0000-0000-0000-000000000000";
         this.serviceToken = "";
+        this.redisUri = "redis://localhost:6379";
     }
 
     /**
@@ -91,6 +100,24 @@ public class BlackholeConfig {
      */
     public void setServiceToken(@NotNull String serviceToken) {
         this.serviceToken = serviceToken;
+    }
+
+    /**
+     * Gets the Redis connection URI used for cross-proxy punishment-state sync.
+     *
+     * @return the Redis URI
+     */
+    public @NotNull String getRedisUri() {
+        return redisUri;
+    }
+
+    /**
+     * Sets the Redis connection URI used for cross-proxy punishment-state sync.
+     *
+     * @param redisUri the Redis URI
+     */
+    public void setRedisUri(@NotNull String redisUri) {
+        this.redisUri = redisUri;
     }
 
     /**

--- a/velocity/src/main/java/net/onelitefeather/blackhole/velocity/listener/PlayerChatListener.java
+++ b/velocity/src/main/java/net/onelitefeather/blackhole/velocity/listener/PlayerChatListener.java
@@ -4,15 +4,16 @@ import com.google.inject.Inject;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.player.PlayerChatEvent;
 import com.velocitypowered.api.proxy.Player;
+import net.kyori.adventure.text.Component;
 import net.onelitefeather.blackhole.client.api.EloApi;
 import net.onelitefeather.blackhole.client.api.PunishProfileApi;
 import net.onelitefeather.blackhole.client.invoker.ApiClient;
 import net.onelitefeather.blackhole.client.invoker.ApiException;
 import net.onelitefeather.blackhole.client.model.ChatSignalDTO;
 import net.onelitefeather.blackhole.client.model.PunishProfileDTO;
-import net.onelitefeather.blackhole.client.model.PunishType;
-import net.onelitefeather.blackhole.velocity.component.PunishmentTemplateComponent;
 import net.onelitefeather.blackhole.velocity.config.BlackholeConfig;
+import net.onelitefeather.blackhole.velocity.redis.PunishmentSyncMessage;
+import net.onelitefeather.blackhole.velocity.redis.RedisSyncService;
 import net.onelitefeather.blackhole.velocity.utils.UUIDConverter;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -27,36 +28,59 @@ public final class PlayerChatListener {
     private final PunishProfileApi punishProfileApi;
     private final EloApi eloApi;
     private final BlackholeConfig config;
+    private final RedisSyncService redisSyncService;
 
     @Inject
-    public PlayerChatListener(@NotNull ApiClient blackholeClient, @NotNull BlackholeConfig config) {
+    public PlayerChatListener(@NotNull ApiClient blackholeClient, @NotNull BlackholeConfig config, @NotNull RedisSyncService redisSyncService) {
         this.punishProfileApi = new PunishProfileApi(blackholeClient);
         this.eloApi = new EloApi(blackholeClient);
         this.config = config;
+        this.redisSyncService = redisSyncService;
     }
 
     @Subscribe
     public void onChat(@NotNull PlayerChatEvent event) {
         Player player = event.getPlayer();
-
         String uuidHash = UUIDConverter.convertToSHA(player.getUniqueId());
-        Optional<PunishProfileDTO> profileOptional;
+
+        Optional<PunishmentSyncMessage> cached = this.redisSyncService.getChatBanFast(uuidHash);
+        if (cached != null) {
+            // A definitive answer from a prior lookup this session - zero network calls, the
+            // whole point of this cache, since PlayerChatEvent fires on every single message.
+            if (cached.isPresent()) {
+                denyChat(event, player);
+            } else {
+                submitChatSignal(player, uuidHash, event.getMessage());
+            }
+            return;
+        }
+
+        // Cache miss (e.g. Redis was down at this player's login) - fall back to the pre-Redis
+        // HTTP check once, then seed the cache so every subsequent message this session is a hit.
+        PunishProfileDTO punishProfile;
         try {
-            profileOptional = Optional.of(this.punishProfileApi.getById(this.config.getTenantId(), uuidHash));
+            punishProfile = this.punishProfileApi.getById(this.config.getTenantId(), uuidHash);
         } catch (ApiException e) {
             LOGGER.error("Failed to fetch punish profile for player {}: {}", player.getUsername(), e.getMessage());
             return;
         }
 
-        PunishProfileDTO punishProfile = profileOptional.get();
-
-        if (punishProfile.getActiveBan() != null && punishProfile.getActiveBan().getTemplate().getType() == PunishType.CHAT) {
-            event.setResult(PlayerChatEvent.ChatResult.denied());
-            player.sendMessage(PunishmentTemplateComponent.of(punishProfile.getActiveBan().getTemplate(), punishProfile));
+        var activeChatBan = punishProfile.getActiveChatBan();
+        if (activeChatBan != null) {
+            this.redisSyncService.seedChatBan(uuidHash, Optional.of(new PunishmentSyncMessage(
+                    this.config.getTenantId(), uuidHash, PunishmentSyncMessage.SLOT_CHAT_BAN, PunishmentSyncMessage.STATE_SET,
+                    "CHAT", activeChatBan.getIdentifier(), null, null
+            )));
+            denyChat(event, player);
             return;
         }
-
+        this.redisSyncService.seedChatBan(uuidHash, Optional.empty());
         submitChatSignal(player, uuidHash, event.getMessage());
+    }
+
+    private void denyChat(PlayerChatEvent event, Player player) {
+        event.setResult(PlayerChatEvent.ChatResult.denied());
+        player.sendMessage(Component.translatable("punishment.error.muted"));
     }
 
     /**

--- a/velocity/src/main/java/net/onelitefeather/blackhole/velocity/listener/PlayerLoginListener.java
+++ b/velocity/src/main/java/net/onelitefeather/blackhole/velocity/listener/PlayerLoginListener.java
@@ -15,6 +15,7 @@ import net.onelitefeather.blackhole.client.model.PunishType;
 import net.onelitefeather.blackhole.client.model.SessionInfoDTO;
 import net.onelitefeather.blackhole.velocity.component.PunishmentTemplateComponent;
 import net.onelitefeather.blackhole.velocity.config.BlackholeConfig;
+import net.onelitefeather.blackhole.velocity.redis.RedisSyncService;
 import net.onelitefeather.blackhole.velocity.utils.UUIDConverter;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -34,12 +35,14 @@ public final class PlayerLoginListener {
     private final PunishProfileApi punishProfileApi;
     private final EvasionApi evasionApi;
     private final BlackholeConfig config;
+    private final RedisSyncService redisSyncService;
 
     @Inject
-    public PlayerLoginListener(@NotNull ApiClient apiClient, @NotNull BlackholeConfig config) {
+    public PlayerLoginListener(@NotNull ApiClient apiClient, @NotNull BlackholeConfig config, @NotNull RedisSyncService redisSyncService) {
         this.punishProfileApi = new PunishProfileApi(apiClient);
         this.evasionApi = new EvasionApi(apiClient);
         this.config = config;
+        this.redisSyncService = redisSyncService;
     }
 
     /**
@@ -54,6 +57,20 @@ public final class PlayerLoginListener {
         // Recorded regardless of ban outcome - catching a banned player re-joining on a fresh
         // account from the same IP is the whole point of ban-evasion detection.
         recordEvasionSignal(player, uuidHash);
+
+        try {
+            var ban = this.redisSyncService.fetchAndTrack(this.config.getTenantId(), uuidHash);
+            if (ban.isPresent() && PunishType.NETWORK.toString().equals(ban.get().type())) {
+                kickForActiveNetworkBan(player, uuidHash);
+                return;
+            }
+            // Redis gave a definitive answer (no active NETWORK ban) - every other proxy already
+            // saw the same state, so there's no need to also ask the backend over HTTP.
+            recordSessionInfo(player, uuidHash);
+            return;
+        } catch (RuntimeException e) {
+            LOGGER.debug("Redis unavailable at login for {}, falling back to HTTP ban check: {}", player.getUsername(), e.getMessage());
+        }
 
         Optional<PunishProfileDTO> profileOptional;
         try {
@@ -71,6 +88,23 @@ public final class PlayerLoginListener {
         }
 
         recordSessionInfo(player, uuidHash);
+    }
+
+    /**
+     * Redis only carries enough of a snapshot to know a NETWORK ban is active, not the full
+     * template needed to render the kick message - one HTTP call still builds that, same as the
+     * pre-Redis behavior.
+     */
+    private void kickForActiveNetworkBan(Player player, String uuidHash) {
+        try {
+            PunishProfileDTO punishProfile = this.punishProfileApi.getById(this.config.getTenantId(), uuidHash);
+            var activeBanDTO = punishProfile.getActiveBan();
+            if (activeBanDTO != null) {
+                player.disconnect(PunishmentTemplateComponent.of(activeBanDTO.getTemplate(), punishProfile));
+            }
+        } catch (ApiException e) {
+            LOGGER.error("Failed to fetch punish profile for banned player {}: {}", player.getUsername(), e.getMessage());
+        }
     }
 
     private void recordEvasionSignal(@NotNull Player player, @NotNull String uuidHash) {

--- a/velocity/src/main/java/net/onelitefeather/blackhole/velocity/module/BlackholeClientModule.java
+++ b/velocity/src/main/java/net/onelitefeather/blackhole/velocity/module/BlackholeClientModule.java
@@ -3,11 +3,12 @@ package net.onelitefeather.blackhole.velocity.module;
 import com.google.inject.AbstractModule;
 import net.onelitefeather.blackhole.client.invoker.ApiClient;
 import net.onelitefeather.blackhole.velocity.config.BlackholeConfig;
+import net.onelitefeather.blackhole.velocity.redis.RedisSyncService;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * The class represents a module for Guice that binds the {@link ApiClient} and {@link BlackholeConfig}
- * to the instances provided in the constructor.
+ * The class represents a module for Guice that binds the {@link ApiClient}, {@link BlackholeConfig}
+ * and {@link RedisSyncService} to the instances provided in the constructor.
  *
  * @author theEvilReaper
  * @version 1.0.0
@@ -17,25 +18,30 @@ public final class BlackholeClientModule extends AbstractModule {
 
     private final ApiClient apiClient;
     private final BlackholeConfig config;
+    private final RedisSyncService redisSyncService;
 
     /**
      * Create a new instance of the module.
      *
-     * @param apiClient the client to bind
-     * @param config    the configuration to bind
+     * @param apiClient        the client to bind
+     * @param config           the configuration to bind
+     * @param redisSyncService the Redis sync service to bind
      */
-    public BlackholeClientModule(@NotNull ApiClient apiClient, @NotNull BlackholeConfig config) {
+    public BlackholeClientModule(@NotNull ApiClient apiClient, @NotNull BlackholeConfig config, @NotNull RedisSyncService redisSyncService) {
         this.apiClient = apiClient;
         this.config = config;
+        this.redisSyncService = redisSyncService;
     }
 
     /**
-     * Configures the module and binds the {@link ApiClient} and {@link BlackholeConfig} to the
-     * instances provided in the constructor. Both instances are bound as singletons.
+     * Configures the module and binds the {@link ApiClient}, {@link BlackholeConfig} and
+     * {@link RedisSyncService} to the instances provided in the constructor. All instances are
+     * bound as singletons.
      */
     @Override
     protected void configure() {
         bind(ApiClient.class).toInstance(this.apiClient);
         bind(BlackholeConfig.class).toInstance(this.config);
+        bind(RedisSyncService.class).toInstance(this.redisSyncService);
     }
 }

--- a/velocity/src/main/java/net/onelitefeather/blackhole/velocity/redis/PunishmentSyncMessage.java
+++ b/velocity/src/main/java/net/onelitefeather/blackhole/velocity/redis/PunishmentSyncMessage.java
@@ -1,0 +1,25 @@
+package net.onelitefeather.blackhole.velocity.redis;
+
+import java.util.UUID;
+
+/**
+ * Mirrors the backend's {@code net.onelitefeather.blackhole.backend.redis.PunishmentSyncMessage}
+ * field-for-field - the JSON shape stored at each Redis key and published on
+ * {@link RedisTopology#PUNISHMENT_SYNC_CHANNEL}. Hand-shared, not part of the OpenAPI client:
+ * this is an internal side channel between the backend and proxies, not a public API contract.
+ */
+public record PunishmentSyncMessage(
+        UUID tenantId,
+        String owner,
+        String slot,
+        String state,
+        String type,
+        String punishmentIdentifier,
+        String templateIdentifier,
+        Long expiresAt
+) {
+    public static final String SLOT_BAN = "BAN";
+    public static final String SLOT_CHAT_BAN = "CHAT_BAN";
+    public static final String STATE_SET = "SET";
+    public static final String STATE_CLEARED = "CLEARED";
+}

--- a/velocity/src/main/java/net/onelitefeather/blackhole/velocity/redis/RedisSyncService.java
+++ b/velocity/src/main/java/net/onelitefeather/blackhole/velocity/redis/RedisSyncService.java
@@ -1,0 +1,216 @@
+package net.onelitefeather.blackhole.velocity.redis;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.connection.DisconnectEvent;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.pubsub.RedisPubSubAdapter;
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
+import net.onelitefeather.blackhole.client.api.PunishProfileApi;
+import net.onelitefeather.blackhole.client.invoker.ApiClient;
+import net.onelitefeather.blackhole.client.invoker.ApiException;
+import net.onelitefeather.blackhole.client.model.PunishEntryDTO;
+import net.onelitefeather.blackhole.client.model.PunishProfileDTO;
+import net.onelitefeather.blackhole.velocity.component.PunishmentTemplateComponent;
+import net.onelitefeather.blackhole.velocity.config.BlackholeConfig;
+import net.onelitefeather.blackhole.velocity.utils.UUIDConverter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Read-only mirror of the backend's Redis-cached active-punishment state (written solely by the
+ * backend's {@code RedisSyncConsumer}). Backs two things:
+ *
+ * <ul>
+ *     <li>a login/chat fast path that avoids an HTTP round-trip to the backend on every check
+ *     ({@link #fetchAndTrack} / {@link #getChatBanFast}), seeded from Redis or, on a cache miss,
+ *     from the caller's own HTTP fallback via {@link #seedChatBan};</li>
+ *     <li>immediate cross-proxy enforcement: when a ban is applied on a different proxy while a
+ *     player is connected to this one, the pub/sub delta received here disconnects them right
+ *     away instead of waiting for their next login.</li>
+ * </ul>
+ *
+ * <p>Every public lookup either returns a definitive answer or throws, so callers can catch and
+ * fall back to the pre-existing HTTP check - Redis being unreachable must never make a
+ * login/chat check fail outright.</p>
+ */
+public final class RedisSyncService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedisSyncService.class);
+
+    private final ProxyServer proxyServer;
+    private final BlackholeConfig config;
+    private final PunishProfileApi punishProfileApi;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /** Absent key = never looked up this session; {@code Optional.empty()} = confirmed inactive. */
+    private final ConcurrentMap<String, Optional<PunishmentSyncMessage>> banCache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Optional<PunishmentSyncMessage>> chatBanCache = new ConcurrentHashMap<>();
+
+    private RedisClient client;
+    private StatefulRedisConnection<String, String> connection;
+    private StatefulRedisPubSubConnection<String, String> pubSubConnection;
+
+    @Inject
+    public RedisSyncService(@NotNull ProxyServer proxyServer, @NotNull BlackholeConfig config, @NotNull ApiClient apiClient) {
+        this.proxyServer = proxyServer;
+        this.config = config;
+        this.punishProfileApi = new PunishProfileApi(apiClient);
+    }
+
+    /**
+     * Connects to Redis and subscribes to the punishment-sync channel. A failure here is logged
+     * and leaves the service disconnected rather than propagating - every proxy must keep working
+     * against the backend over plain HTTP if Redis is unavailable at startup.
+     */
+    public void connect() {
+        try {
+            this.client = RedisClient.create(this.config.getRedisUri());
+            this.connection = this.client.connect();
+            this.pubSubConnection = this.client.connectPubSub();
+            this.pubSubConnection.addListener(new RedisPubSubAdapter<String, String>() {
+                @Override
+                public void message(String channel, String message) {
+                    onMessage(message);
+                }
+            });
+            this.pubSubConnection.sync().subscribe(RedisTopology.PUNISHMENT_SYNC_CHANNEL);
+            LOGGER.info("Connected to Redis for cross-proxy punishment sync at {}", this.config.getRedisUri());
+        } catch (RuntimeException e) {
+            LOGGER.error("Failed to connect to Redis at {} - falling back to per-request HTTP checks: {}", this.config.getRedisUri(), e.getMessage());
+            shutdown();
+        }
+    }
+
+    public void shutdown() {
+        if (this.pubSubConnection != null) {
+            this.pubSubConnection.close();
+            this.pubSubConnection = null;
+        }
+        if (this.connection != null) {
+            this.connection.close();
+            this.connection = null;
+        }
+        if (this.client != null) {
+            this.client.shutdown();
+            this.client = null;
+        }
+    }
+
+    /**
+     * Reads both the ban and chat-ban keys for {@code ownerHash} and seeds both local caches from
+     * the result, so the chat check right after login is a guaranteed cache hit.
+     *
+     * @return the active ban, if any
+     * @throws IllegalStateException if Redis isn't connected - callers must fall back to HTTP
+     */
+    public Optional<PunishmentSyncMessage> fetchAndTrack(@NotNull UUID tenantId, @NotNull String ownerHash) {
+        requireConnected();
+        RedisCommands<String, String> sync = this.connection.sync();
+        Optional<PunishmentSyncMessage> ban = parse(sync.get(RedisTopology.banKey(tenantId, ownerHash)));
+        Optional<PunishmentSyncMessage> chat = parse(sync.get(RedisTopology.chatBanKey(tenantId, ownerHash)));
+        this.banCache.put(ownerHash, ban);
+        this.chatBanCache.put(ownerHash, chat);
+        return ban;
+    }
+
+    /**
+     * @return {@code null} if this player's mute state was never looked up this session (caller
+     * must fall back to HTTP and then call {@link #seedChatBan}), otherwise a definitive answer
+     */
+    public @Nullable Optional<PunishmentSyncMessage> getChatBanFast(@NotNull String ownerHash) {
+        return this.chatBanCache.get(ownerHash);
+    }
+
+    public void seedChatBan(@NotNull String ownerHash, @NotNull Optional<PunishmentSyncMessage> value) {
+        this.chatBanCache.put(ownerHash, value);
+    }
+
+    @Subscribe
+    public void onDisconnect(@NotNull DisconnectEvent event) {
+        String ownerHash = UUIDConverter.convertToSHA(event.getPlayer().getUniqueId());
+        this.banCache.remove(ownerHash);
+        this.chatBanCache.remove(ownerHash);
+    }
+
+    private void onMessage(String rawJson) {
+        PunishmentSyncMessage message;
+        try {
+            message = this.objectMapper.readValue(rawJson, PunishmentSyncMessage.class);
+        } catch (JsonProcessingException e) {
+            LOGGER.warn("Failed to parse incoming punishment sync message: {}", e.getMessage());
+            return;
+        }
+        if (!message.tenantId().equals(this.config.getTenantId())) {
+            return;
+        }
+
+        boolean active = PunishmentSyncMessage.STATE_SET.equals(message.state());
+        Optional<PunishmentSyncMessage> value = active ? Optional.of(message) : Optional.empty();
+
+        if (PunishmentSyncMessage.SLOT_CHAT_BAN.equals(message.slot())) {
+            this.chatBanCache.put(message.owner(), value);
+            return;
+        }
+
+        this.banCache.put(message.owner(), value);
+        if (active) {
+            kickIfConnectedHere(message);
+        }
+    }
+
+    /**
+     * A ban was just applied on (possibly) another proxy. The owner hash is one-way, so the only
+     * way to tell whether the affected player is connected to this proxy is to hash every
+     * currently-online player and compare - the same thing {@code PlayerLoginListener}/
+     * {@code PlayerChatListener} already do per-player, just run here across the online list.
+     */
+    private void kickIfConnectedHere(PunishmentSyncMessage message) {
+        for (Player player : this.proxyServer.getAllPlayers()) {
+            if (!UUIDConverter.convertToSHA(player.getUniqueId()).equals(message.owner())) {
+                continue;
+            }
+            try {
+                PunishProfileDTO profile = this.punishProfileApi.getById(this.config.getTenantId(), message.owner());
+                PunishEntryDTO activeBan = profile.getActiveBan();
+                if (activeBan != null) {
+                    player.disconnect(PunishmentTemplateComponent.of(activeBan.getTemplate(), profile));
+                }
+            } catch (ApiException e) {
+                LOGGER.error("Failed to fetch profile for cross-proxy kick of {}: {}", player.getUsername(), e.getMessage());
+            }
+            return;
+        }
+    }
+
+    private Optional<PunishmentSyncMessage> parse(@Nullable String json) {
+        if (json == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(this.objectMapper.readValue(json, PunishmentSyncMessage.class));
+        } catch (JsonProcessingException e) {
+            LOGGER.warn("Failed to parse cached punishment sync value: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private void requireConnected() {
+        if (this.connection == null) {
+            throw new IllegalStateException("Redis is not connected");
+        }
+    }
+}

--- a/velocity/src/main/java/net/onelitefeather/blackhole/velocity/redis/RedisTopology.java
+++ b/velocity/src/main/java/net/onelitefeather/blackhole/velocity/redis/RedisTopology.java
@@ -1,0 +1,25 @@
+package net.onelitefeather.blackhole.velocity.redis;
+
+import java.util.UUID;
+
+/**
+ * Mirrors the backend's {@code net.onelitefeather.blackhole.backend.redis.RedisTopology}
+ * byte-for-byte - the channel name and key format are a hand-shared contract between the
+ * backend (the sole writer) and every Velocity proxy (a reader only).
+ */
+final class RedisTopology {
+
+    static final String PUNISHMENT_SYNC_CHANNEL = "blackhole.punishment.sync";
+
+    static String banKey(UUID tenantId, String owner) {
+        return "blackhole:punish:ban:" + tenantId + ":" + owner;
+    }
+
+    static String chatBanKey(UUID tenantId, String owner) {
+        return "blackhole:punish:chatban:" + tenantId + ":" + owner;
+    }
+
+    private RedisTopology() {
+        throw new UnsupportedOperationException("This class cannot be instantiated");
+    }
+}

--- a/velocity/src/main/resources/blackhole_de.properties
+++ b/velocity/src/main/resources/blackhole_de.properties
@@ -2,10 +2,17 @@ prefix
 string_empty=
 target_not_online=Der spezifische Spieler ist nicht online
 punishment.error.mute=Beim Stummschalten des Spielers ist ein Fehler aufgetreten.
+punishment.error.muted=Du bist derzeit stummgeschaltet und kannst keine Chatnachrichten senden.
 punishment.error.template.not_found=Bestrafungsvorlage mit der ID <arg:0> wurde nicht gefunden.
 punishment.error.ban=Beim Bannen des Spielers ist ein Fehler aufgetreten.
 punishment.error.template.only_server=Du kannst einen Spieler nur mit einer Server-Vorlage vom Server bannen.
 punishment.success.ban=Du hast <arg:0> erfolgreich gebannt.
+punishment.error.unban=Beim Entbannen des Spielers ist ein Fehler aufgetreten.
+punishment.error.unban.none_active=Dieser Spieler hat keinen aktiven Bann, der aufgehoben werden kann.
+punishment.success.unban=Du hast <arg:0> erfolgreich entbannt.
+punishment.error.unmute=Beim Aufheben der Stummschaltung ist ein Fehler aufgetreten.
+punishment.error.unmute.none_active=Dieser Spieler hat keine aktive Stummschaltung, die aufgehoben werden kann.
+punishment.success.unmute=Du hast die Stummschaltung von <arg:0> erfolgreich aufgehoben.
 duration.now=jetzt
 duration.in=in <arg:0>
 duration.day.one=<arg:0> Tag

--- a/velocity/src/main/resources/blackhole_en.properties
+++ b/velocity/src/main/resources/blackhole_en.properties
@@ -1,9 +1,16 @@
 target_not_online=The target player is not online
 punishment.error.mute=An error occurred while trying to mute the player.
+punishment.error.muted=You are currently muted and cannot send chat messages.
 punishment.error.template.not_found=Punishment template with ID <arg:0> was not found.
 punishment.error.ban=An error occurred while trying to ban the player.
 punishment.error.template.only_server=You can only ban a player from the server with a server template.
 punishment.success.ban=You have banned <arg:0> successfully.
+punishment.error.unban=An error occurred while trying to unban the player.
+punishment.error.unban.none_active=This player has no active ban to revoke.
+punishment.success.unban=You have unbanned <arg:0> successfully.
+punishment.error.unmute=An error occurred while trying to unmute the player.
+punishment.error.unmute.none_active=This player has no active mute to revoke.
+punishment.success.unmute=You have unmuted <arg:0> successfully.
 duration.now=now
 duration.in=in <arg:0>
 duration.day.one=<arg:0> day


### PR DESCRIPTION
## Summary
- Backend-driven Redis mirror of active bans/mutes (bridging `punishment.created`/`expired`/`revoked` and `appeal.resolved` domain events via a new `RedisSyncConsumer`), so every Velocity proxy in a multi-proxy network sees consistent state without an HTTP call on every login/chat message.
- Immediate cross-proxy enforcement: a ban applied while a player is connected to a different proxy now disconnects them via Redis pub/sub instead of waiting for their next login.
- New pardon (unban/unmute) path end-to-end: backend revoke endpoints + `PunishmentApplicationService.revokeBan/revokeMute`, regenerated OpenAPI client (`blackhole-api-0.0.4.yml`), and new `/unban`/`/unmute` Velocity commands.
- Fixes a pre-existing bug in `PlayerChatListener`: it checked `getActiveBan()` for chat mutes instead of `getActiveChatBan()`, so chat mutes were never actually enforced.
- New `redis` service in `docker/docker-compose.yml`; new `io.micronaut.redis:micronaut-redis-lettuce` (backend) / `io.lettuce:lettuce-core` (Velocity) dependencies.

## Test plan
- [x] `./gradlew clean build -x test` succeeds across all modules
- [x] Backend boots cleanly against the full docker-compose stack (mariadb + rabbitmq + redis)
- [x] Applied a NETWORK ban via curl — confirmed Redis key `SET` with correct `PSETEX` TTL and `SET` pub/sub delta on `blackhole.punishment.sync`
- [x] Revoked the ban via the new endpoint — confirmed Redis key deleted, `CLEARED` pub/sub delta, punishment moved into profile history
- [x] Repeated for a CHAT mute (`chatban` key) via apply + revoke
- [ ] Manual two-proxy cross-proxy kick/mute test with real Velocity instances (not run in this environment — no Minecraft client available)