### PR TITLE
chore: centralize renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    ":semanticCommitsDisabled"
-  ],
-  "labels": ["renovate"],
-  "rebaseWhen": "conflicted"
+    "github>OneLiteFeatherNET/renovate:default(OneLiteFeatherNET/blackhole-maintainers)"
+  ]
 }


### PR DESCRIPTION
## Summary
- Replace the ad-hoc local `renovate.json` with the org's centralized preset (`github>OneLiteFeatherNET/renovate:default(...)`), matching how `Otis`, `Titan`, and `Stardust` are configured.
- Create the `OneLiteFeatherNET/blackhole-maintainers` team (closed, `pull` access on this repo) and set it as the PR reviewer via the shared preset's `default` parameter.

## Test plan
- [ ] Confirm Renovate picks up the new config on its next run against this branch/PR and opens/updates dependency PRs as expected
- [ ] Confirm `blackhole-maintainers` is requested as reviewer on the next Renovate PR