### PR TITLE
feat!: publish velocity module and unify Maven groupId to net.onelitefeather

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -4,8 +4,6 @@ plugins {
     `maven-publish`
 }
 
-group = "net.onelitefeather.blackhole"
-
 dependencies {
     annotationProcessor(mn.micronaut.serde.processor)
     annotationProcessor(mn.micronaut.http.validation)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@
 // release-please rewrites on every release. Java .properties syntax only treats `#` as a comment
 // starter at the start of a line, so the raw value includes that trailing comment - strip it here.
 allprojects {
+    group = "net.onelitefeather"
     version = (version as String).substringBefore('#').trim()
 }
 

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -3,8 +3,6 @@ plugins {
     alias(libs.plugins.openapi.generator)
 }
 
-group = "net.onelitefeather"
-
 val outDir = layout.buildDirectory.dir("generated/openapi")
 
 dependencies {
@@ -36,7 +34,7 @@ openApiGenerate {
             "useJakartaEe" to "true",
             "serializationLibrary" to "jackson",
             "artifactId" to "blackhole-client",
-            "groupId" to "net.onelitefeather.blackhole",
+            "groupId" to "net.onelitefeather",
             "artifactVersion" to rootProject.version.toString(),
             "buildTool" to "gradle",
             "generateBuilders" to "true",

--- a/phoca/build.gradle.kts
+++ b/phoca/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     `maven-publish`
 }
 
-group = "net.onelitefeather.phoca"
 version = "0.5.3"
 
 repositories {

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -1,5 +1,3 @@
-group = "net.onelitefeather.blackhole.velocity"
-
 plugins {
     id("xyz.jpenilla.run-velocity") version "3.0.2"
     `maven-publish`
@@ -34,5 +32,62 @@ tasks {
         // This is the only required configuration besides applying the plugin.
         // Your plugin's jar (or shadowJar if present) will be used automatically.
         velocityVersion("3.3.0-SNAPSHOT")
+    }
+}
+
+publishing {
+    publications.create<MavenPublication>("maven") {
+        artifact(tasks.shadowJar)
+        version = rootProject.version as String
+        artifactId = "blackhole-velocity"
+        groupId = project.group as String
+        pom {
+            name = "Blackhole Velocity"
+            description = "A Velocity proxy plugin that enforces punishments and feeds chat/session data to the Blackhole backend"
+            url = "https://github.com/OneLiteFeatherNET/Blackhole"
+            licenses {
+                license {
+                    name = "AGPL-3.0"
+                    url = "https://www.gnu.org/licenses/agpl-3.0.en.html"
+                }
+            }
+            developers {
+                developer {
+                    id = "themeinerlp"
+                    name = "Phillipp Glanz"
+                    email = "p.glanz@madfix.me"
+                }
+                developer {
+                    id = "theEvilReaper"
+                    name = "Steffen Wonning"
+                    email = "steffenwx@gmail.com"
+                }
+            }
+            scm {
+                connection = "scm:git:git://github.com:OneLiteFeatherNET/Blackhole.git"
+                developerConnection = "scm:git:ssh://git@github.com:OneLiteFeatherNET/Blackhole.git"
+                url = "https://github.com/OneLiteFeatherNET/Blackhole"
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            authentication {
+                credentials(PasswordCredentials::class) {
+                    // Those credentials need to be set under "Settings -> Secrets -> Actions" in your repository
+                    username = System.getenv("ONELITEFEATHER_MAVEN_USERNAME")
+                    password = System.getenv("ONELITEFEATHER_MAVEN_PASSWORD")
+                }
+            }
+
+            name = "OneLiteFeatherRepository"
+            val releasesRepoUrl = uri("https://repo.onelitefeather.dev/onelitefeather-releases")
+            val snapshotsRepoUrl = uri("https://repo.onelitefeather.dev/onelitefeather-snapshots")
+            url =
+                if (version.toString().contains("SNAPSHOT") || version.toString().contains("BETA") || version.toString()
+                        .contains("ALPHA")
+                ) snapshotsRepoUrl else releasesRepoUrl
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Sets a single `group = "net.onelitefeather"` at the root project for all modules instead of divergent per-module group ids (`net.onelitefeather.blackhole`, `net.onelitefeather.blackhole.velocity`, `net.onelitefeather.phoca`).
- Adds the previously-missing `publishing{}` block (with `groupId`) to the `velocity` module, matching the existing `backend`/`client` publishing setup (publishes the shadow jar to the `OneLiteFeatherRepository`).

## Breaking change
Published Maven coordinates for the `backend` artifact change groupId from `net.onelitefeather.blackhole` to `net.onelitefeather` (artifactId `blackhole-backend` is unchanged). `client` already used `net.onelitefeather`; `velocity` is newly published under `net.onelitefeather:blackhole-velocity`.

## Test plan
- [x] `./gradlew clean build -x test` succeeds
- [x] `./gradlew :velocity:generatePomFileForMavenPublication :backend:generatePomFileForMavenPublication :client:generatePomFileForMavenPublication` succeeds and generated POMs all carry `groupId = net.onelitefeather`