### PR TITLE
feat: add pluggable player-name resolver for offline-player bans

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -15,6 +15,10 @@ dependencies {
     implementation(mn.micronaut.runtime)
     implementation(mn.validation)
     implementation(mn.micronaut.http.client.jdk)
+    // Otis (net.onelitefeather.otis) is the team's own player master-data service - its
+    // generated client is published to the same OneLiteFeatherRepository declared in
+    // settings.gradle.kts, the same way this project publishes its own `client` module.
+    implementation("net.onelitefeather.otis:otis-client:1.16.0")
     implementation(mn.micronaut.management)
     implementation(mn.micronaut.micrometer.core)
     implementation(mn.micronaut.micrometer.registry.prometheus)

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -15,10 +15,13 @@ dependencies {
     implementation(mn.micronaut.runtime)
     implementation(mn.validation)
     implementation(mn.micronaut.http.client.jdk)
-    // Otis (net.onelitefeather.otis) is the team's own player master-data service - its
-    // generated client is published to the same OneLiteFeatherRepository declared in
-    // settings.gradle.kts, the same way this project publishes its own `client` module.
-    implementation("net.onelitefeather.otis:otis-client:1.16.0")
+    // Otis is the team's own player master-data service - its generated client is published to
+    // the same OneLiteFeatherRepository declared in settings.gradle.kts, the same way this
+    // project publishes its own `client` module. Its Maven groupId is the shared org-wide
+    // "net.onelitefeather" (from Otis's rootProject.group), NOT "net.onelitefeather.otis" -
+    // that longer name is only the Java package prefix its OpenAPI generator emits
+    // (net.onelitefeather.otis.client.*), a separate, unrelated setting.
+    implementation("net.onelitefeather:otis-client:1.16.0")
     implementation(mn.micronaut.management)
     implementation(mn.micronaut.micrometer.core)
     implementation(mn.micronaut.micrometer.registry.prometheus)

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/controller/PlayerLookupApi.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/controller/PlayerLookupApi.java
@@ -1,0 +1,37 @@
+package net.onelitefeather.blackhole.backend.controller;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.PathVariable;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import net.onelitefeather.blackhole.backend.dto.PlayerResolveDTO;
+
+public interface PlayerLookupApi {
+
+    @Operation(
+            description = "Resolve a player name to a UUID via the configured resolver chain (Otis, Mojang, NameMC)",
+            operationId = "resolvePlayer",
+            tags = {"Player"}
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "The player was resolved",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PlayerResolveDTO.Response.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "No resolver could find a player with that name",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PlayerResolveDTO.Error.class)
+            )
+    )
+    @Get("/resolve/{name}")
+    HttpResponse<PlayerResolveDTO> resolve(@PathVariable String name);
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/controller/PlayerLookupController.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/controller/PlayerLookupController.java
@@ -1,0 +1,29 @@
+package net.onelitefeather.blackhole.backend.controller;
+
+import io.micronaut.core.version.annotation.Version;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Controller;
+import jakarta.inject.Inject;
+import net.onelitefeather.blackhole.backend.dto.PlayerResolveDTO;
+import net.onelitefeather.blackhole.backend.playerresolver.PlayerLookupService;
+
+@Version(ApiVersion.V1)
+@Controller("/player")
+public class PlayerLookupController implements PlayerLookupApi {
+
+    private final PlayerLookupService playerLookupService;
+
+    @Inject
+    public PlayerLookupController(PlayerLookupService playerLookupService) {
+        this.playerLookupService = playerLookupService;
+    }
+
+    @Override
+    public HttpResponse<PlayerResolveDTO> resolve(String name) {
+        PlayerResolveDTO result = this.playerLookupService.resolve(name);
+        if (result instanceof PlayerResolveDTO.Error) {
+            return HttpResponse.notFound(result);
+        }
+        return HttpResponse.ok(result);
+    }
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/dto/PlayerResolveDTO.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/dto/PlayerResolveDTO.java
@@ -1,0 +1,31 @@
+package net.onelitefeather.blackhole.backend.dto;
+
+import io.micronaut.serde.annotation.Serdeable;
+import io.swagger.v3.oas.annotations.media.Schema;
+import net.onelitefeather.blackhole.backend.playerresolver.ResolvedPlayer;
+import net.onelitefeather.blackhole.backend.response.ErrorResponse;
+
+import java.util.UUID;
+
+/**
+ * Wire contract for {@code GET /player/resolve/{name}} - a read-only lookup, so unlike a
+ * mutable resource's DTO this only needs a success/error pair, no Create/Update request variants.
+ */
+@Schema(description = "DTO for resolving a player name to a UUID")
+@Serdeable
+public sealed interface PlayerResolveDTO {
+
+    @Schema(name = "PlayerResolveResponse")
+    @Serdeable
+    record Response(UUID uuid, String name, String source) implements PlayerResolveDTO {
+
+        public static Response of(ResolvedPlayer resolved) {
+            return new Response(resolved.uuid(), resolved.name(), resolved.source());
+        }
+    }
+
+    @Schema(name = "PlayerResolveError")
+    @Serdeable
+    record Error(String errorMessage) implements PlayerResolveDTO, ErrorResponse {
+    }
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/MojangApiClient.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/MojangApiClient.java
@@ -1,0 +1,23 @@
+package net.onelitefeather.blackhole.backend.playerresolver;
+
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.serde.annotation.Serdeable;
+
+import java.util.Optional;
+
+/**
+ * Mojang's official (unauthenticated, rate-limited) name-to-UUID API - a no-content 204 response
+ * means "no such player", which Micronaut maps straight to {@link Optional#empty()} for an
+ * {@code Optional<T>} return type.
+ */
+@Client(id = "mojang", value = "https://api.mojang.com")
+public interface MojangApiClient {
+
+    @Get("/users/profiles/minecraft/{username}")
+    Optional<Profile> getProfile(String username);
+
+    @Serdeable
+    record Profile(String id, String name) {
+    }
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/MojangPlayerResolver.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/MojangPlayerResolver.java
@@ -1,0 +1,52 @@
+package net.onelitefeather.blackhole.backend.playerresolver;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Order;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Fallback resolver: Mojang's official name-to-UUID API. Tried only once Otis has already come
+ * back empty (see {@link PlayerResolverService}).
+ */
+@Singleton
+@Order(20)
+@Requires(property = "blackhole.player-resolver.mojang.enabled", value = "true", defaultValue = "true")
+public class MojangPlayerResolver implements PlayerResolver {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MojangPlayerResolver.class);
+
+    private final MojangApiClient client;
+
+    public MojangPlayerResolver(MojangApiClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public Optional<ResolvedPlayer> resolve(String name) {
+        try {
+            return this.client.getProfile(name)
+                    .map(profile -> new ResolvedPlayer(dashedUuid(profile.id()), profile.name(), "mojang"));
+        } catch (HttpClientResponseException e) {
+            if (e.getStatus().getCode() != 404) {
+                LOGGER.warn("Mojang lookup failed for player {}: {}", name, e.getMessage());
+            }
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Mojang returns the UUID without dashes; {@link UUID#fromString(String)} requires them.
+     */
+    private static UUID dashedUuid(String undashed) {
+        return UUID.fromString(undashed.replaceFirst(
+                "(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})",
+                "$1-$2-$3-$4-$5"
+        ));
+    }
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/NameMcApiClient.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/NameMcApiClient.java
@@ -1,0 +1,17 @@
+package net.onelitefeather.blackhole.backend.playerresolver;
+
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.QueryValue;
+import io.micronaut.http.client.annotation.Client;
+
+/**
+ * NameMC has no official public API - this hits its regular player-search HTML page, the same
+ * one a browser would load, since that's the only lookup surface it exposes. See
+ * {@link NameMcPlayerResolver} for why this is treated as best-effort only.
+ */
+@Client(id = "namemc", value = "https://namemc.com")
+public interface NameMcApiClient {
+
+    @Get("/search?q={query}&type=exact")
+    String search(@QueryValue String query);
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/NameMcPlayerResolver.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/NameMcPlayerResolver.java
@@ -1,0 +1,57 @@
+package net.onelitefeather.blackhole.backend.playerresolver;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Order;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Lowest-priority, best-effort resolver. NameMC has no official API and no stability guarantee
+ * on the page it exposes ("may change or disappear at any time" per every third-party wrapper of
+ * it) - disabled by default (see {@code blackhole.player-resolver.namemc.enabled}), and any
+ * failure here (network, HTML shape change, anything) must fall through to "no match" rather
+ * than break the resolver chain or the command that triggered it.
+ */
+@Singleton
+@Order(30)
+@Requires(property = "blackhole.player-resolver.namemc.enabled", value = "true", defaultValue = "false")
+public class NameMcPlayerResolver implements PlayerResolver {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NameMcPlayerResolver.class);
+    private static final Pattern PROFILE_LINK = Pattern.compile("/profile/([0-9a-fA-F-]{32,36})");
+
+    private final NameMcApiClient client;
+
+    public NameMcPlayerResolver(NameMcApiClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public Optional<ResolvedPlayer> resolve(String name) {
+        try {
+            String html = this.client.search(name);
+            Matcher matcher = PROFILE_LINK.matcher(html);
+            if (!matcher.find()) {
+                return Optional.empty();
+            }
+            UUID uuid = UUID.fromString(normalizeToDashed(matcher.group(1)));
+            return Optional.of(new ResolvedPlayer(uuid, name, "namemc"));
+        } catch (Exception e) {
+            LOGGER.debug("NameMC lookup failed for player {}: {}", name, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private static String normalizeToDashed(String uuid) {
+        if (uuid.contains("-")) {
+            return uuid;
+        }
+        return uuid.replaceFirst("(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})", "$1-$2-$3-$4-$5");
+    }
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/OtisPlayerResolver.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/OtisPlayerResolver.java
@@ -1,0 +1,51 @@
+package net.onelitefeather.blackhole.backend.playerresolver;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.core.annotation.Order;
+import jakarta.inject.Singleton;
+import net.onelitefeather.otis.client.api.PlayerApi;
+import net.onelitefeather.otis.client.invoker.ApiClient;
+import net.onelitefeather.otis.client.invoker.ApiException;
+import net.onelitefeather.otis.client.model.OtisPlayerDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+/**
+ * Resolves via Otis, the team's own in-house player master-data service - the primary, most
+ * trustworthy resolver in the chain (see {@link PlayerResolverService}).
+ */
+@Singleton
+@Order(10)
+@Requires(property = "blackhole.player-resolver.otis.enabled", value = "true", defaultValue = "true")
+@Requires(property = "blackhole.player-resolver.otis.base-url", pattern = ".+")
+public class OtisPlayerResolver implements PlayerResolver {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OtisPlayerResolver.class);
+
+    private final PlayerApi playerApi;
+
+    public OtisPlayerResolver(@Value("${blackhole.player-resolver.otis.base-url}") String baseUrl) {
+        ApiClient apiClient = new ApiClient();
+        apiClient.setBasePath(baseUrl);
+        this.playerApi = new PlayerApi(apiClient);
+    }
+
+    @Override
+    public Optional<ResolvedPlayer> resolve(String name) {
+        try {
+            OtisPlayerDTO player = this.playerApi.getPlayerByName(name);
+            if (player == null || player.getPlayerUuid() == null) {
+                return Optional.empty();
+            }
+            return Optional.of(new ResolvedPlayer(player.getPlayerUuid(), player.getPlayerName(), "otis"));
+        } catch (ApiException e) {
+            if (e.getCode() != 404) {
+                LOGGER.warn("Otis lookup failed for player {}: {}", name, e.getMessage());
+            }
+            return Optional.empty();
+        }
+    }
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/PlayerLookupService.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/PlayerLookupService.java
@@ -1,0 +1,27 @@
+package net.onelitefeather.blackhole.backend.playerresolver;
+
+import jakarta.inject.Singleton;
+import net.onelitefeather.blackhole.backend.dto.PlayerResolveDTO;
+
+import java.util.regex.Pattern;
+
+@Singleton
+public class PlayerLookupService {
+
+    private static final Pattern VALID_NAME = Pattern.compile("^[a-zA-Z0-9_]{3,16}$");
+
+    private final PlayerResolverService resolverService;
+
+    public PlayerLookupService(PlayerResolverService resolverService) {
+        this.resolverService = resolverService;
+    }
+
+    public PlayerResolveDTO resolve(String name) {
+        if (!VALID_NAME.matcher(name).matches()) {
+            return new PlayerResolveDTO.Error("Not a valid Minecraft player name");
+        }
+        return this.resolverService.resolve(name)
+                .<PlayerResolveDTO>map(PlayerResolveDTO.Response::of)
+                .orElseGet(() -> new PlayerResolveDTO.Error("No resolver found a player named " + name));
+    }
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/PlayerResolveCache.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/PlayerResolveCache.java
@@ -1,0 +1,39 @@
+package net.onelitefeather.blackhole.backend.playerresolver;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.micronaut.context.annotation.Value;
+import jakarta.inject.Singleton;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * In-memory cache for resolved name-to-UUID lookups, keyed by lowercased name. Mirrors
+ * {@code ProfileCache}'s shape but, unlike it, isn't wired into the cross-replica invalidation
+ * fanout - resolved-name data barely ever changes, so a short TTL is a sufficient staleness bound
+ * on its own.
+ */
+@Singleton
+public class PlayerResolveCache {
+
+    private final Cache<String, ResolvedPlayer> cache;
+
+    public PlayerResolveCache(
+            @Value("${blackhole.player-resolver.cache.ttl}") Duration ttl,
+            @Value("${blackhole.player-resolver.cache.max-size}") long maxSize
+    ) {
+        this.cache = Caffeine.newBuilder()
+                .maximumSize(maxSize)
+                .expireAfterWrite(ttl)
+                .build();
+    }
+
+    public Optional<ResolvedPlayer> get(String name) {
+        return Optional.ofNullable(this.cache.getIfPresent(name.toLowerCase()));
+    }
+
+    public void put(String name, ResolvedPlayer resolved) {
+        this.cache.put(name.toLowerCase(), resolved);
+    }
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/PlayerResolver.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/PlayerResolver.java
@@ -1,0 +1,15 @@
+package net.onelitefeather.blackhole.backend.playerresolver;
+
+import java.util.Optional;
+
+/**
+ * A single external name-to-UUID lookup source. Implementations are ordered via
+ * {@link io.micronaut.core.annotation.Order} and tried in sequence by
+ * {@link PlayerResolverService} until one returns a hit - a failing or disabled resolver must
+ * never break the chain, so implementations should turn "not found"/errors into
+ * {@link Optional#empty()} rather than throwing.
+ */
+public interface PlayerResolver {
+
+    Optional<ResolvedPlayer> resolve(String name);
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/PlayerResolverService.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/PlayerResolverService.java
@@ -1,0 +1,49 @@
+package net.onelitefeather.blackhole.backend.playerresolver;
+
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Walks every enabled {@link PlayerResolver} in {@link io.micronaut.core.annotation.Order}
+ * order and returns the first hit. Micronaut injects the list already sorted, so adding another
+ * resolver later is just another {@code @Singleton} bean - no change here.
+ */
+@Singleton
+public class PlayerResolverService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlayerResolverService.class);
+
+    private final List<PlayerResolver> resolvers;
+    private final PlayerResolveCache cache;
+
+    public PlayerResolverService(List<PlayerResolver> resolvers, PlayerResolveCache cache) {
+        this.resolvers = resolvers;
+        this.cache = cache;
+    }
+
+    public Optional<ResolvedPlayer> resolve(String name) {
+        Optional<ResolvedPlayer> cached = this.cache.get(name);
+        if (cached.isPresent()) {
+            return cached;
+        }
+
+        for (PlayerResolver resolver : this.resolvers) {
+            Optional<ResolvedPlayer> result;
+            try {
+                result = resolver.resolve(name);
+            } catch (Exception e) {
+                LOGGER.warn("{} threw while resolving player {}: {}", resolver.getClass().getSimpleName(), name, e.getMessage());
+                continue;
+            }
+            if (result.isPresent()) {
+                this.cache.put(name, result.get());
+                return result;
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/ResolvedPlayer.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/playerresolver/ResolvedPlayer.java
@@ -1,0 +1,10 @@
+package net.onelitefeather.blackhole.backend.playerresolver;
+
+import java.util.UUID;
+
+/**
+ * @param source which {@link PlayerResolver} produced this result, e.g. {@code "otis"} - kept in
+ *               the DTO response so callers/logs can tell where a UUID came from.
+ */
+public record ResolvedPlayer(UUID uuid, String name, String source) {
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/response/ErrorResponse.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/response/ErrorResponse.java
@@ -1,0 +1,11 @@
+package net.onelitefeather.blackhole.backend.response;
+
+/**
+ * Marker for a DTO's error variant, so any resource's expected-failure response can be handled
+ * generically instead of every resource nesting its own unrelated error shape (see
+ * {@code net.onelitefeather.blackhole.backend.dto.PlayerResolveDTO.Error} for the first user).
+ */
+public interface ErrorResponse {
+
+    String errorMessage();
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -132,6 +132,30 @@ blackhole:
     detection-window-days: ${BLACKHOLE_EVASION_DETECTION_WINDOW_DAYS:7}
     retention-days: ${BLACKHOLE_EVASION_RETENTION_DAYS:90}
     retention-sweep-cron: ${BLACKHOLE_EVASION_RETENTION_SWEEP_CRON:`0 30 3 * * *`}
+  # Player-name resolution, so moderators can tab-complete and target an OFFLINE player by name
+  # (punishment enforcement is already fully UUID-driven at login - see PlayerLoginListener on
+  # the Velocity side - so resolving a name to a UUID is the only missing piece). Resolvers are
+  # tried in a fixed priority order (Otis, then Mojang, then NameMC) and the chain stops at the
+  # first hit; disabling one is a config change only, not a code change.
+  player-resolver:
+    cache:
+      ttl: ${BLACKHOLE_PLAYER_RESOLVER_CACHE_TTL:PT5M}
+      max-size: ${BLACKHOLE_PLAYER_RESOLVER_CACHE_MAX_SIZE:5000}
+    # Otis is the team's own in-house player master-data service - the primary, most trustworthy
+    # resolver. base-url has no default: it's a per-deployment private service address, unlike
+    # Mojang's fixed public API below, so the resolver bean only loads once it's actually set.
+    otis:
+      enabled: ${BLACKHOLE_PLAYER_RESOLVER_OTIS_ENABLED:true}
+      base-url: ${BLACKHOLE_PLAYER_RESOLVER_OTIS_BASE_URL:}
+    # Mojang's official name->UUID API - no auth, but rate-limited, so kept as a fallback rather
+    # than the primary source.
+    mojang:
+      enabled: ${BLACKHOLE_PLAYER_RESOLVER_MOJANG_ENABLED:true}
+    # NameMC has no official public API - only undocumented endpoints that "may change or
+    # disappear at any time" per every third-party wrapper. Lowest priority, and disabled by
+    # default: an operator has to explicitly opt into that instability.
+    namemc:
+      enabled: ${BLACKHOLE_PLAYER_RESOLVER_NAMEMC_ENABLED:false}
 
 micronaut:
   application:

--- a/backend/src/test/java/net/onelitefeather/blackhole/backend/playerresolver/PlayerResolverServiceTest.java
+++ b/backend/src/test/java/net/onelitefeather/blackhole/backend/playerresolver/PlayerResolverServiceTest.java
@@ -1,0 +1,80 @@
+package net.onelitefeather.blackhole.backend.playerresolver;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PlayerResolverServiceTest {
+
+    private static PlayerResolverService serviceOf(List<PlayerResolver> resolvers) {
+        return new PlayerResolverService(resolvers, new PlayerResolveCache(Duration.ofMinutes(5), 100));
+    }
+
+    private static PlayerResolver fixedResolver(String forName, ResolvedPlayer result) {
+        return candidate -> candidate.equals(forName) ? Optional.of(result) : Optional.empty();
+    }
+
+    @Test
+    void returnsTheFirstResolverInOrderThatHasAHit() {
+        ResolvedPlayer fromOtis = new ResolvedPlayer(UUID.randomUUID(), "Steve", "otis");
+        ResolvedPlayer fromMojang = new ResolvedPlayer(UUID.randomUUID(), "Steve", "mojang");
+        PlayerResolverService service = serviceOf(List.of(
+                fixedResolver("Steve", fromOtis),
+                fixedResolver("Steve", fromMojang)
+        ));
+
+        assertEquals(Optional.of(fromOtis), service.resolve("Steve"));
+    }
+
+    @Test
+    void fallsThroughToTheNextResolverWhenTheFirstMisses() {
+        ResolvedPlayer fromMojang = new ResolvedPlayer(UUID.randomUUID(), "Alex", "mojang");
+        PlayerResolverService service = serviceOf(List.of(
+                name -> Optional.empty(),
+                fixedResolver("Alex", fromMojang)
+        ));
+
+        assertEquals(Optional.of(fromMojang), service.resolve("Alex"));
+    }
+
+    @Test
+    void aResolverThrowingDoesNotBreakTheChain() {
+        ResolvedPlayer fallback = new ResolvedPlayer(UUID.randomUUID(), "Herobrine", "namemc");
+        PlayerResolverService service = serviceOf(List.of(
+                name -> {
+                    throw new RuntimeException("boom");
+                },
+                fixedResolver("Herobrine", fallback)
+        ));
+
+        assertEquals(Optional.of(fallback), service.resolve("Herobrine"));
+    }
+
+    @Test
+    void returnsEmptyWhenNoResolverHasAMatch() {
+        PlayerResolverService service = serviceOf(List.of(name -> Optional.empty()));
+
+        assertTrue(service.resolve("Nobody").isEmpty());
+    }
+
+    @Test
+    void cachesAHitSoTheSameResolverIsNotCalledTwice() {
+        ResolvedPlayer resolved = new ResolvedPlayer(UUID.randomUUID(), "Notch", "otis");
+        int[] calls = {0};
+        PlayerResolverService service = serviceOf(List.of(name -> {
+            calls[0]++;
+            return Optional.of(resolved);
+        }));
+
+        service.resolve("Notch");
+        service.resolve("Notch");
+
+        assertEquals(1, calls[0]);
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,10 @@ subprojects {
 
     tasks {
         getByName<JavaCompile>("compileJava") {
-            options.release.set(21)
+            // Matches the toolchain (JavaLanguageVersion 25) each module already builds with -
+            // otis-client (a backend dependency) is published targeting Java 25 with no lower
+            // --release cap, so a 21 target here made it an incompatible dependency variant.
+            options.release.set(25)
             options.encoding = "UTF-8"
         }
         getByName<JacocoReport>("jacocoTestReport") {

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 openApiGenerate {
     generatorName.set("java")
     library.set("native")
-    inputSpec.set("$projectDir/specs/blackhole-api-0.0.7.yml")
+    inputSpec.set("$projectDir/specs/blackhole-api-0.0.8.yml")
     outputDir.set(outDir.get().asFile.absolutePath)
     apiPackage.set("net.onelitefeather.blackhole.client.api")
     invokerPackage.set("net.onelitefeather.blackhole.client.invoker")

--- a/client/specs/blackhole-api-0.0.8.yml
+++ b/client/specs/blackhole-api-0.0.8.yml
@@ -1,0 +1,1796 @@
+openapi: 3.0.1
+info:
+  title: Blackhole API
+  description: Simple ban management system
+  contact:
+    name: Management
+    url: https://onelitefeather.net
+    email: admin@onelitefeather.net
+  license:
+    name: Close Source
+  version: 0.0.8
+paths:
+  /appeal:
+    get:
+      tags:
+      - Appeal
+      summary: Get all appeals
+      description: Retrieves a paginated list of appeals
+      operationId: getAppeals
+      parameters:
+      - name: pageable
+        in: query
+        required: true
+        explode: false
+        schema:
+          $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          description: Successfully retrieved appeals
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AppealDTO"
+    post:
+      tags:
+      - Appeal
+      summary: Submit an appeal
+      description: Submits an appeal against a punishment. Immediately evaluated against
+        the eligibility checklist.
+      operationId: submitAppeal
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AppealSubmissionDTO"
+        required: true
+      responses:
+        "200":
+          description: Appeal submitted (status reflects whether it passed the eligibility
+            checklist)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppealDTO"
+        "404":
+          description: Punishment not found
+  /appeal/{identifier}/review:
+    post:
+      tags:
+      - Appeal
+      summary: Review an appeal
+      description: Decides an eligible appeal. Rejects self-review (reviewerId matching
+        the punishment's own source) and full lifts of SEVERE punishments (duration
+        reduction only).
+      operationId: reviewAppeal
+      parameters:
+      - name: identifier
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AppealReviewDTO"
+        required: true
+      responses:
+        "200":
+          description: Appeal decided
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppealDTO"
+        "404":
+          description: Appeal not found
+        "400":
+          description: "Invalid decision, or a full lift was attempted on a SEVERE\
+            \ punishment"
+        "403":
+          description: reviewerId matches the punishment's original source (self-review)
+        "409":
+          description: "Appeal is not awaiting review, or the punishment is no longer\
+            \ active"
+  /connector:
+    get:
+      tags:
+      - Connector
+      summary: Get all connectors
+      operationId: getConnectors
+      parameters:
+      - name: pageable
+        in: query
+        required: true
+        explode: false
+        schema:
+          $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          description: getConnectors 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Page_ConnectorRegistrationDTO_"
+    post:
+      tags:
+      - Connector
+      summary: Register a connector
+      operationId: registerConnector
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectorRegistrationRequestDTO"
+        required: true
+      responses:
+        "200":
+          description: registerConnector 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorRegistrationCreatedDTO"
+  /connector/subscription:
+    post:
+      tags:
+      - Connector
+      summary: Create an event subscription for a connector
+      operationId: addEventSubscription
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EventSubscriptionRequestDTO"
+        required: true
+      responses:
+        "400":
+          description: deliveryUrl failed SSRF validation (see message)
+        "200":
+          description: addEventSubscription 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+  /connector/subscription/{identifier}:
+    delete:
+      tags:
+      - Connector
+      summary: Delete an event subscription
+      operationId: removeEventSubscription
+      parameters:
+      - name: identifier
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: removeEventSubscription 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventSubscriptionDTO"
+  /connector/{connectorId}/subscription:
+    get:
+      tags:
+      - Connector
+      summary: Get all event subscriptions for a connector
+      operationId: getEventSubscriptions
+      parameters:
+      - name: connectorId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: pageable
+        in: query
+        required: true
+        explode: false
+        schema:
+          $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          description: getEventSubscriptions 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Page_EventSubscriptionDTO_"
+  /connector/{identifier}:
+    get:
+      tags:
+      - Connector
+      summary: Get a connector by ID
+      operationId: getConnectorById
+      parameters:
+      - name: identifier
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: getConnectorById 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorRegistrationDTO"
+    delete:
+      tags:
+      - Connector
+      summary: Delete a connector
+      operationId: removeConnector
+      parameters:
+      - name: identifier
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: removeConnector 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorRegistrationDTO"
+  /connector/{identifier}/update:
+    post:
+      tags:
+      - Connector
+      summary: Update a connector's name/scopes/status
+      operationId: updateConnector
+      parameters:
+      - name: identifier
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectorRegistrationDTO"
+        required: true
+      responses:
+        "200":
+          description: updateConnector 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorRegistrationDTO"
+  /elo/chat:
+    post:
+      tags:
+      - Elo
+      summary: Score a chat message for toxicity
+      description: "Scores a chat message; if flagged, records evidence (a hash, never\
+        \ the raw text) and applies a chat-ELO delta"
+      operationId: submitChatSignal
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChatSignalDTO"
+        required: true
+      responses:
+        "200":
+          description: Scoring result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChatToxicityResult"
+  /elo/{owner}:
+    get:
+      tags:
+      - Elo
+      summary: Get a player's current ELO standing
+      description: "Dashboard read endpoint: the current chat/gameplay scores"
+      operationId: getEloProfile
+      parameters:
+      - name: owner
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Current ELO profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EloProfileDTO"
+        "404":
+          description: No ELO profile exists yet for this owner
+  /elo/{owner}/history:
+    get:
+      tags:
+      - Elo
+      summary: Get a player's ELO history
+      description: "Dashboard read endpoint: the full audit trail of ELO changes for\
+        \ this owner"
+      operationId: getEloHistory
+      parameters:
+      - name: owner
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: pageable
+        in: query
+        required: true
+        explode: false
+        schema:
+          $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          description: Paginated ELO event history
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/EloEventDTO"
+  /evasion/record:
+    post:
+      tags:
+      - Evasion
+      summary: Record a login sighting for ban-evasion detection
+      description: Computes a keyed hash of the IP (never stores it raw) and checks
+        whether multiple distinct owners share it recently
+      operationId: recordEvasionSighting
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EvasionRecordDTO"
+        required: true
+      responses:
+        "200":
+          description: Recorded
+          content:
+            application/json:
+              schema:
+                type: object
+        "503":
+          description: blackhole.evasion.ip-salt is not configured - evasion detection
+            is disabled
+  /player/resolve/{name}:
+    get:
+      tags:
+      - Player
+      summary: Resolve a player name to a UUID via the configured resolver chain
+        (Otis, Mojang, NameMC)
+      description: Resolve a player name to a UUID via the configured resolver
+        chain (Otis, Mojang, NameMC)
+      operationId: resolvePlayer
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The player was resolved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlayerResolveResponse"
+        "404":
+          description: No resolver could find a player with that name
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlayerResolveError"
+  /profile:
+    get:
+      tags:
+      - PunishProfile
+      summary: Get all punishment profiles.
+      description: Get all existing punishment profiles
+      operationId: getProfiles
+      parameters:
+      - name: pageable
+        in: query
+        required: true
+        explode: false
+        schema:
+          $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          description: The updated profile
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PunishProfileResponse"
+    post:
+      tags:
+      - PunishProfile
+      summary: Add a new punishment profile.
+      description: Add a new profile for punishments
+      operationId: addProfile
+      requestBody:
+        description: the profile to add
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PunishProfileRequestDTO"
+        required: true
+      responses:
+        "200":
+          description: The profile which was added to the service
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishProfileResponse"
+  /profile/delete/{owner}:
+    delete:
+      tags:
+      - PunishProfile
+      summary: Delete a punishment profile by the owner.
+      description: Delete a punish profile via uuid
+      operationId: removeProfile
+      parameters:
+      - name: owner
+        in: path
+        description: the owner of the profile
+        required: true
+        schema:
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: Owner must be a sha-512 hash
+      responses:
+        "200":
+          description: The deleted profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishProfileResponse"
+        "400":
+          description: Error message when there is no profile linked to the given
+            id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /profile/update/{owner}:
+    post:
+      tags:
+      - PunishProfile
+      summary: Get a punishment profile by the owner.
+      description: Update a punishment profile
+      operationId: updateProfile
+      parameters:
+      - name: owner
+        in: path
+        required: true
+        schema:
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: Owner must be a sha-512 hash
+      requestBody:
+        description: the profile to get
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PunishProfileRequestDTO"
+        required: true
+      responses:
+        "200":
+          description: The updated profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishProfileResponse"
+        "400":
+          description: Error message when there is no profile linked to the given
+            id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /profile/{owner}:
+    get:
+      tags:
+      - PunishProfile
+      summary: Get a punishment profile by the owner.
+      description: Get a profile by id
+      operationId: getById
+      parameters:
+      - name: owner
+        in: path
+        required: true
+        schema:
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: Owner must be a sha-512 hash
+      responses:
+        "200":
+          description: The profile which matches with the given id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishProfileDTO"
+        "404":
+          description: Error message when there is no profile linked to the given
+            id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /profile/{owner}/session:
+    post:
+      tags:
+      - PunishProfile
+      summary: "Records session telemetry (Phase 7's dashboard enrichment: Java/Bedrock\
+        \ protocol version and client brand) into the profile's existing metaData,\
+        \ so the already-existing profile listing/get endpoints surface it without\
+        \ a separate dashboard endpoint."
+      description: Records session telemetry (protocol version / client brand) for
+        the dashboard
+      operationId: updateSessionInfo
+      parameters:
+      - name: owner
+        in: path
+        required: true
+        schema:
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: Owner must be a sha-512 hash
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SessionInfoDTO"
+        required: true
+      responses:
+        "200":
+          description: Session info recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishProfileResponse"
+  /punishment:
+    get:
+      tags:
+      - Punishment
+      summary: Get all punishments
+      description: Retrieves a paginated list of all punishment entries in the system
+      operationId: getPunishments
+      parameters:
+      - name: pageable
+        in: query
+        required: true
+        explode: false
+        schema:
+          $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          description: Successfully retrieved punishment entries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PunishEntryDTO"
+  /punishment/active/{owner}/ban/revoke/{source}:
+    post:
+      tags:
+      - Punishment
+      summary: Revoke active ban
+      description: "Revokes a player's active ban (SERVER or NETWORK), moving it into\
+        \ history"
+      operationId: revokeBan
+      parameters:
+      - name: owner
+        in: path
+        description: the owner of the punishment
+        required: true
+        schema:
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: Owner must be a sha-512 hash
+      - name: source
+        in: path
+        description: the staff/system identity revoking the punishment
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Ban successfully revoked
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishProfileResponse"
+        "404":
+          description: "Profile not found, or has no active ban"
+        "400":
+          description: Invalid input parameters (owner must be SHA-512 hash)
+  /punishment/active/{owner}/mute/revoke/{source}:
+    post:
+      tags:
+      - Punishment
+      summary: Revoke active mute
+      description: "Revokes a player's active chat ban, moving it into history"
+      operationId: revokeMute
+      parameters:
+      - name: owner
+        in: path
+        description: the owner of the punishment
+        required: true
+        schema:
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: Owner must be a sha-512 hash
+      - name: source
+        in: path
+        description: the staff/system identity revoking the punishment
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Mute successfully revoked
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishProfileResponse"
+        "404":
+          description: "Profile not found, or has no active mute"
+        "400":
+          description: Invalid input parameters (owner must be SHA-512 hash)
+  /punishment/active/{owner}/{templateId}/{source}:
+    post:
+      tags:
+      - Punishment
+      summary: Add active punishment
+      description: Creates and applies an active punishment to a player profile based
+        on a punishment template
+      operationId: addActivePunishment
+      parameters:
+      - name: owner
+        in: path
+        description: the owner of the punishment
+        required: true
+        schema:
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: Owner must be a sha-512 hash
+      - name: templateId
+        in: path
+        description: the template id of the punishment
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: source
+        in: path
+        description: the source of the punishment
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Punishment successfully applied to profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishProfileResponse"
+        "404":
+          description: Profile or template not found
+        "400":
+          description: Invalid input parameters (owner must be SHA-512 hash)
+  /report:
+    get:
+      tags:
+      - Report
+      summary: Get all reports
+      description: Retrieves a paginated list of reports
+      operationId: getReports
+      parameters:
+      - name: pageable
+        in: query
+        required: true
+        explode: false
+        schema:
+          $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          description: Successfully retrieved reports
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ReportDTO"
+    post:
+      tags:
+      - Report
+      summary: Submit a report
+      description: Submits a player report. Rate-limited per reporterHash within a
+        configurable time window.
+      operationId: submitReport
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReportRequestDTO"
+        required: true
+      responses:
+        "200":
+          description: Report successfully submitted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReportDTO"
+        "429":
+          description: Rate limit exceeded for this reporter
+  /report/{identifier}/resolve:
+    post:
+      tags:
+      - Report
+      summary: Resolve a report
+      description: "Resolves a report, optionally applying a punishment template to\
+        \ the reported player"
+      operationId: resolveReport
+      parameters:
+      - name: identifier
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReportResolutionDTO"
+        required: true
+      responses:
+        "200":
+          description: Report successfully resolved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReportDTO"
+        "404":
+          description: Report or punishment template not found
+        "400":
+          description: punishmentSource is required when punishmentTemplateId is set
+  /signal:
+    post:
+      tags:
+      - Signal
+      summary: Submit an external signal
+      operationId: submitSignal
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SignalDTO"
+        required: true
+      responses:
+        "200":
+          description: submitSignal 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+  /template:
+    get:
+      tags:
+      - Punishment Templates
+      summary: Get all punishment templates
+      description: Retrieves a paginated list of all punishment templates in the system
+      operationId: getAllTemplates
+      parameters:
+      - name: pageable
+        in: query
+        required: true
+        explode: false
+        schema:
+          $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          description: Successfully retrieved punishment templates
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PunishTemplateDTO"
+    post:
+      tags:
+      - Punishment Templates
+      summary: Create punishment template
+      description: Creates a new punishment template.
+      operationId: addTemplate
+      requestBody:
+        description: the template to add
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PunishTemplateRequestDTO"
+        required: true
+      responses:
+        "200":
+          description: Template successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishTemplateDTO"
+        "405":
+          description: Method not allowed - identifier must be null for creation
+        "400":
+          description: Invalid template data
+  /template/delete/{identifier}:
+    delete:
+      tags:
+      - Punishment Templates
+      summary: Delete punishment template
+      description: Deletes a punishment template by its identifier
+      operationId: deleteTemplate
+      parameters:
+      - name: identifier
+        in: path
+        description: the identifier of the template to remove
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Template successfully deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishTemplateDTO"
+        "404":
+          description: Template not found
+  /template/update:
+    post:
+      tags:
+      - Punishment Templates
+      summary: Update punishment template
+      description: Updates an existing punishment template.
+      operationId: updateTemplate
+      requestBody:
+        description: the template to update
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PunishTemplateRequestDTO"
+        required: true
+      responses:
+        "200":
+          description: Template successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishTemplateDTO"
+        "404":
+          description: Template not found
+        "400":
+          description: Invalid template data
+  /template/{identifier}:
+    get:
+      tags:
+      - Punishment Templates
+      summary: Get punishment template by ID
+      description: Retrieves a specific punishment template by its identifier
+      operationId: getTemplateById
+      parameters:
+      - name: identifier
+        in: path
+        description: the identifier of the template to retrieve
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Template successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PunishTemplateDTO"
+        "404":
+          description: Template not found
+components:
+  schemas:
+    AppealDTO:
+      required:
+      - appellantHash
+      - createdAt
+      - eligibilityCheckResult
+      - identifier
+      - metaData
+      - punishmentIdentifier
+      - statement
+      - status
+      - updatedAt
+      type: object
+      properties:
+        identifier:
+          type: string
+          format: uuid
+        punishmentIdentifier:
+          type: string
+        appellantHash:
+          type: string
+        statement:
+          type: string
+        status:
+          $ref: "#/components/schemas/AppealStatus"
+        eligibilityCheckResult:
+          type: object
+          additionalProperties:
+            type: object
+        decidedBy:
+          type: string
+          format: uuid
+          nullable: true
+        decisionNote:
+          type: string
+          nullable: true
+        createdAt:
+          type: integer
+          format: int64
+        updatedAt:
+          type: integer
+          format: int64
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+    AppealReviewDTO:
+      required:
+      - decision
+      - reviewerId
+      type: object
+      properties:
+        decision:
+          $ref: "#/components/schemas/AppealStatus"
+        decisionNote:
+          maxLength: 2000
+          type: string
+          description: an optional note explaining the decision
+          nullable: true
+        reviewerId:
+          type: string
+          description: the staff/system identity making this decision; rejected if
+            it matches the punishment's own `source` (self-review exclusion)
+          format: uuid
+        newExpirationAt:
+          type: integer
+          description: "required when `decision` is `GRANTED_DURATION_REDUCTION` -\
+            \ the new, sooner expiration timestamp (epoch millis)"
+          format: int64
+          nullable: true
+    AppealStatus:
+      type: string
+      description: The lifecycle state of an appeal.
+      enum:
+      - SUBMITTED
+      - ELIGIBLE_PENDING_REVIEW
+      - IN_REVIEW
+      - GRANTED_FULL_LIFT
+      - GRANTED_DURATION_REDUCTION
+      - DENIED
+      - INELIGIBLE
+    AppealSubmissionDTO:
+      required:
+      - appellantHash
+      - punishmentIdentifier
+      - statement
+      type: object
+      properties:
+        punishmentIdentifier:
+          minLength: 1
+          type: string
+        appellantHash:
+          minLength: 1
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: appellantHash must be a sha-512 hash
+        statement:
+          maxLength: 2000
+          minLength: 1
+          type: string
+    ChatSignalDTO:
+      required:
+      - message
+      - owner
+      type: object
+      properties:
+        owner:
+          minLength: 1
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: owner must be a sha-512 hash
+        message:
+          maxLength: 512
+          minLength: 1
+          type: string
+    ChatToxicityResult:
+      required:
+      - flagged
+      - score
+      type: object
+      properties:
+        flagged:
+          type: boolean
+        score:
+          type: number
+          format: double
+    ConnectorRegistrationCreatedDTO:
+      required:
+      - connector
+      - oauth2ClientSecret
+      type: object
+      properties:
+        connector:
+          $ref: "#/components/schemas/ConnectorRegistrationDTO"
+        oauth2ClientSecret:
+          type: string
+      description: Response to a connector registration. `oauth2ClientSecret` is the
+        only time the plaintext secret is ever shown - only the SHA-512 hash is persisted.
+    ConnectorRegistrationDTO:
+      required:
+      - identifier
+      - metaData
+      - name
+      - oauth2ClientId
+      - scopes
+      - status
+      type: object
+      properties:
+        identifier:
+          type: string
+          format: uuid
+        name:
+          type: string
+        oauth2ClientId:
+          type: string
+        scopes:
+          type: array
+          items:
+            type: string
+        status:
+          $ref: "#/components/schemas/ConnectorStatus"
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+      description: "Representation of a registered connector. Deliberately never carries\
+        \ the client secret (or its hash) - that's only ever shown once, at creation\
+        \ time, via ConnectorRegistrationCreatedDTO."
+    ConnectorRegistrationRequestDTO:
+      required:
+      - name
+      - scopes
+      type: object
+      properties:
+        name:
+          minLength: 1
+          type: string
+        scopes:
+          minItems: 1
+          type: array
+          items:
+            type: string
+    ConnectorStatus:
+      type: string
+      description: Whether a registered connector may currently authenticate/receive
+        webhook deliveries.
+      enum:
+      - ACTIVE
+      - SUSPENDED
+    EloEventDTO:
+      required:
+      - createdAt
+      - delta
+      - identifier
+      - metaData
+      - owner
+      - reasonCode
+      - resultingScore
+      - track
+      type: object
+      properties:
+        identifier:
+          type: string
+          format: uuid
+        owner:
+          type: string
+        track:
+          $ref: "#/components/schemas/EloTrack"
+        delta:
+          type: integer
+          format: int32
+        reasonCode:
+          $ref: "#/components/schemas/EloReasonCode"
+        sourceEvidenceId:
+          type: string
+          format: uuid
+          nullable: true
+        resultingScore:
+          type: integer
+          format: int32
+        createdAt:
+          type: integer
+          format: int64
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+    EloProfileDTO:
+      required:
+      - chatElo
+      - chatEloUpdatedAt
+      - gameplayElo
+      - gameplayEloUpdatedAt
+      - metaData
+      - owner
+      type: object
+      properties:
+        owner:
+          type: string
+        chatElo:
+          type: integer
+          format: int32
+        gameplayElo:
+          type: integer
+          format: int32
+        chatEloUpdatedAt:
+          type: integer
+          format: int64
+        gameplayEloUpdatedAt:
+          type: integer
+          format: int64
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+    EloReasonCode:
+      type: string
+      description: Why an `EloEventEntity` happened. This is the audit trail that
+        lets a reviewer (or a future Phase 6 appeal) tell an algorithmic decision
+        apart from a human one.
+      enum:
+      - TOXICITY_FLAG
+      - ANTICHEAT_FLAG
+      - REPORT_ACTIONED
+      - MANUAL_ADJUSTMENT
+      - DECAY_RECOVERY
+      - THRESHOLD_BAN
+      - PUNISHMENT_APPLIED
+      - REPORT_REWARDED
+    EloTrack:
+      type: string
+      description: "The two independent ELO tracks. A player can play without chatting\
+        \ (or vice versa), so each track must be able to trigger consequences on its\
+        \ own - a silent cheater must be caught by the gameplay track even with zero\
+        \ chat activity, and a toxic-but-legitimate player must be caught by the chat\
+        \ track even with clean gameplay."
+      enum:
+      - CHAT
+      - GAMEPLAY
+    ErrorResponse:
+      type: object
+      properties:
+        The error message:
+          type: string
+          description: the error message
+      description: The error response when something went wrong on profile requests
+    EvasionRecordDTO:
+      required:
+      - ip
+      - owner
+      type: object
+      properties:
+        owner:
+          minLength: 1
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: owner must be a sha-512 hash
+        ip:
+          minLength: 1
+          type: string
+    EventSubscriptionDTO:
+      required:
+      - active
+      - connectorId
+      - deliveryUrl
+      - eventTypes
+      - failureCount
+      - identifier
+      - metaData
+      type: object
+      properties:
+        identifier:
+          type: string
+          format: uuid
+        connectorId:
+          type: string
+          format: uuid
+        eventTypes:
+          type: array
+          items:
+            type: string
+        deliveryUrl:
+          type: string
+        active:
+          type: boolean
+        failureCount:
+          type: integer
+          format: int32
+        lastAttemptAt:
+          type: integer
+          format: int64
+          nullable: true
+        lastSuccessAt:
+          type: integer
+          format: int64
+          nullable: true
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+      description: "Representation of a connector's event subscription. Never carries\
+        \ the signing secret - that's only shown once, at creation time, via EventSubscriptionCreatedDTO."
+    EventSubscriptionRequestDTO:
+      required:
+      - connectorId
+      - deliveryUrl
+      - eventTypes
+      type: object
+      properties:
+        connectorId:
+          type: string
+          format: uuid
+        eventTypes:
+          minItems: 1
+          type: array
+          items:
+            type: string
+        deliveryUrl:
+          minLength: 1
+          type: string
+    Page_ConnectorRegistrationDTO_:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Slice_ConnectorRegistrationDTO_"
+      - type: object
+        properties:
+          totalSize:
+            type: integer
+            format: int64
+          totalPages:
+            type: integer
+            format: int32
+    Page_EventSubscriptionDTO_:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Slice_EventSubscriptionDTO_"
+      - type: object
+        properties:
+          totalSize:
+            type: integer
+            format: int64
+          totalPages:
+            type: integer
+            format: int32
+    Pageable:
+      required:
+      - size
+      - sort
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Sort"
+      - type: object
+        properties:
+          number:
+            type: integer
+            format: int32
+          size:
+            type: integer
+            format: int32
+          mode:
+            $ref: "#/components/schemas/Pageable.Mode"
+          sort:
+            $ref: "#/components/schemas/Sort"
+    Pageable.Mode:
+      type: string
+      enum:
+      - CURSOR_NEXT
+      - CURSOR_PREVIOUS
+      - OFFSET
+    PlayerResolveError:
+      required:
+      - errorMessage
+      type: object
+      properties:
+        errorMessage:
+          type: string
+      description: DTO for resolving a player name to a UUID
+    PlayerResolveResponse:
+      required:
+      - name
+      - source
+      - uuid
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        name:
+          type: string
+        source:
+          type: string
+      description: DTO for resolving a player name to a UUID
+    PunishEntryDTO:
+      required:
+      - identifier
+      - metaData
+      - scope
+      - source
+      - template
+      - type
+      type: object
+      properties:
+        identifier:
+          type: string
+          description: the identifier of the punishment
+        source:
+          type: string
+          description: the source of the punishment
+          format: uuid
+        type:
+          $ref: "#/components/schemas/PunishType"
+        scope:
+          type: string
+          description: "the optional scope (e.g. event/community) this punishment\
+            \ is restricted to, or `null` for network-wide"
+        template:
+          $ref: "#/components/schemas/PunishTemplateDTO"
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+          description: the metadata of the punishment
+      description: Represents a punish entry which can be used to store the punishment
+        in the database.
+    PunishProfileDTO:
+      required:
+      - metaData
+      - owner
+      type: object
+      properties:
+        activeChatBan:
+          nullable: true
+          allOf:
+          - $ref: "#/components/schemas/PunishEntryDTO"
+        activeBan:
+          nullable: true
+          allOf:
+          - $ref: "#/components/schemas/PunishEntryDTO"
+        owner:
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: Owner must be a sha-512 hash
+        history:
+          type: array
+          nullable: true
+          items:
+            $ref: "#/components/schemas/PunishEntryDTO"
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+    PunishProfileRequestDTO:
+      required:
+      - metaData
+      - owner
+      type: object
+      properties:
+        owner:
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: Owner must be a sha-512 hash
+        activeChatBan:
+          nullable: true
+          allOf:
+          - $ref: "#/components/schemas/PunishEntryDTO"
+        activeBan:
+          nullable: true
+          allOf:
+          - $ref: "#/components/schemas/PunishEntryDTO"
+        history:
+          type: array
+          nullable: true
+          items:
+            $ref: "#/components/schemas/PunishEntryDTO"
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+      description: Request body for creating/updating a punishment profile.
+    PunishProfileResponse:
+      type: object
+    PunishTemplateDTO:
+      required:
+      - eloDelta
+      - metaData
+      - reason
+      - type
+      type: object
+      properties:
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+        reason:
+          minLength: 1
+          type: string
+        type:
+          $ref: "#/components/schemas/PunishType"
+        eloDelta:
+          type: integer
+          format: int32
+        identifier:
+          type: string
+          format: uuid
+          nullable: true
+    PunishTemplateRequestDTO:
+      required:
+      - eloDelta
+      - metaData
+      - reason
+      - type
+      type: object
+      properties:
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+        reason:
+          minLength: 1
+          type: string
+        type:
+          $ref: "#/components/schemas/PunishType"
+        eloDelta:
+          type: integer
+          format: int32
+        identifier:
+          type: string
+          format: uuid
+          nullable: true
+      description: "Request body for creating/updating a punishment template. `identifier`\
+        \ is `null` for creation, set for update - the same nullable-identifier-means-create\
+        \ convention used elsewhere."
+    PunishType:
+      type: string
+      description: |-
+        This enumeration defines each type of ban which is supported by the application.
+
+
+        The following types are supported:
+
+        * Server: means that a target is banned from a specific server
+        * Network: means that a target is banned from the whole network
+        * Chat: means that a target is banned from the chat
+      enum:
+      - SERVER
+      - NETWORK
+      - CHAT
+    ReportCategory:
+      type: string
+      description: What kind of behavior a report is about.
+      enum:
+      - CHAT_ABUSE
+      - CHEATING
+      - GRIEFING
+      - OTHER
+    ReportDTO:
+      required:
+      - category
+      - createdAt
+      - metaData
+      - reportedHash
+      - reporterHash
+      - updatedAt
+      type: object
+      properties:
+        identifier:
+          type: string
+          description: "the identifier of the report, `null` when submitting"
+          format: uuid
+          nullable: true
+        reporterHash:
+          minLength: 1
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          description: SHA-512 hash of the reporting player
+          x-pattern-message: reporterHash must be a sha-512 hash
+        reportedHash:
+          minLength: 1
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          description: SHA-512 hash of the reported player
+          x-pattern-message: reportedHash must be a sha-512 hash
+        category:
+          $ref: "#/components/schemas/ReportCategory"
+        description:
+          maxLength: 1000
+          type: string
+          description: a bounded free-text description
+          nullable: true
+        evidenceReferences:
+          type: array
+          description: optional references to `PunishmentEvidenceEntity` entries
+          nullable: true
+          items:
+            type: string
+            format: uuid
+        status:
+          nullable: true
+          allOf:
+          - $ref: "#/components/schemas/ReportStatus"
+        createdAt:
+          type: integer
+          description: epoch millis when the report was submitted
+          format: int64
+        updatedAt:
+          type: integer
+          description: epoch millis of the last status change
+          format: int64
+        resolvedBy:
+          type: string
+          description: "the staff/system identity that resolved this report, if resolved"
+          format: uuid
+          nullable: true
+        resolutionNote:
+          maxLength: 1000
+          type: string
+          description: "a note explaining the resolution, if resolved"
+          nullable: true
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+          description: extensible metadata
+      description: A player report. `status`/`createdAt`/`updatedAt`/`resolvedBy`/
+        `resolutionNote` are server-controlled - a submission simply leaves them unset/default.
+    ReportRequestDTO:
+      required:
+      - category
+      - metaData
+      - reportedHash
+      - reporterHash
+      type: object
+      properties:
+        reporterHash:
+          minLength: 1
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          description: SHA-512 hash of the reporting player
+          x-pattern-message: reporterHash must be a sha-512 hash
+        reportedHash:
+          minLength: 1
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          description: SHA-512 hash of the reported player
+          x-pattern-message: reportedHash must be a sha-512 hash
+        category:
+          $ref: "#/components/schemas/ReportCategory"
+        description:
+          maxLength: 1000
+          type: string
+          description: a bounded free-text description
+          nullable: true
+        evidenceReferences:
+          type: array
+          description: optional references to `PunishmentEvidenceEntity` entries
+          nullable: true
+          items:
+            type: string
+            format: uuid
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+          description: extensible metadata
+      description: "Request body for submitting a player report. `status`/`createdAt`/\
+        \ `updatedAt`/`resolvedBy`/`resolutionNote` are server-controlled and have\
+        \ no place here - see ReportDTO, the response type, for those."
+    ReportResolutionDTO:
+      required:
+      - resolvedBy
+      - status
+      type: object
+      properties:
+        status:
+          $ref: "#/components/schemas/ReportStatus"
+        resolutionNote:
+          maxLength: 1000
+          type: string
+          description: an optional note explaining the decision
+          nullable: true
+        resolvedBy:
+          type: string
+          description: the staff/system identity resolving this report
+          format: uuid
+        punishmentTemplateId:
+          type: string
+          description: an optional template to apply to the reported player
+          format: uuid
+          nullable: true
+        punishmentSource:
+          type: string
+          description: the staff/system identity applying the punishment; required
+            if `punishmentTemplateId` is set
+          format: uuid
+          nullable: true
+      description: Request body for resolving a report. Providing `punishmentTemplateId`
+        (together with `punishmentSource`) applies that template to the reported player
+        as part of the same resolution - the report system's actual integration point
+        with punishments.
+    ReportStatus:
+      type: string
+      description: The lifecycle state of a report.
+      enum:
+      - OPEN
+      - UNDER_REVIEW
+      - ACTIONED
+      - DISMISSED
+    SessionInfoDTO:
+      required:
+      - owner
+      type: object
+      properties:
+        owner:
+          minLength: 1
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          x-pattern-message: owner must be a sha-512 hash
+        protocolVersion:
+          type: integer
+          format: int32
+          nullable: true
+        clientBrand:
+          maxLength: 64
+          type: string
+          nullable: true
+      description: "Session telemetry captured at login/brand-negotiation time (Phase\
+        \ 7's dashboard enrichment). Both fields are optional and merged, not overwritten,\
+        \ into the profile's existing session info - `protocolVersion` arrives at\
+        \ login, `clientBrand` arrives slightly later as a separate plugin-channel\
+        \ negotiation, so a single caller rarely has both at once."
+    SignalDTO:
+      required:
+      - metaData
+      - owner
+      - payload
+      - signalType
+      type: object
+      properties:
+        owner:
+          minLength: 1
+          pattern: "^[a-fA-F0-9]{128}$"
+          type: string
+          description: SHA-512 hash of the affected player
+          x-pattern-message: owner must be a sha-512 hash
+        signalType:
+          minLength: 1
+          type: string
+          description: "a connector-chosen identifier, e.g. `anticheat.flag`"
+        payload:
+          type: object
+          additionalProperties:
+            type: object
+          description: signal-specific data
+        metaData:
+          type: object
+          additionalProperties:
+            type: object
+          description: extensible metadata
+      description: A generic external signal (e.g. an anticheat flag) ingested via
+        `POST /signal`. Deliberately opaque - Blackhole doesn't know or care what
+        `signalType` values a given connector uses; it's published as a domain event
+        and Phase 5's ELO system (or any other consumer) decides what to do with it.
+        This is what keeps the connector framework generic rather than anticheat-specific.
+    Slice_ConnectorRegistrationDTO_:
+      required:
+      - content
+      - pageable
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/ConnectorRegistrationDTO"
+        pageable:
+          $ref: "#/components/schemas/Pageable"
+        pageNumber:
+          type: integer
+          format: int32
+        offset:
+          type: integer
+          format: int64
+        size:
+          type: integer
+          format: int32
+        empty:
+          type: boolean
+        numberOfElements:
+          type: integer
+          format: int32
+    Slice_EventSubscriptionDTO_:
+      required:
+      - content
+      - pageable
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/EventSubscriptionDTO"
+        pageable:
+          $ref: "#/components/schemas/Pageable"
+        pageNumber:
+          type: integer
+          format: int32
+        offset:
+          type: integer
+          format: int64
+        size:
+          type: integer
+          format: int32
+        empty:
+          type: boolean
+        numberOfElements:
+          type: integer
+          format: int32
+    Sort:
+      required:
+      - orderBy
+      type: object
+      properties:
+        orderBy:
+          type: array
+          items:
+            $ref: "#/components/schemas/Sort.Order"
+    Sort.Order:
+      required:
+      - direction
+      - ignoreCase
+      - property
+      type: object
+      properties:
+        ignoreCase:
+          type: boolean
+        direction:
+          $ref: "#/components/schemas/Sort.Order.Direction"
+        property:
+          type: string
+        ascending:
+          type: boolean
+    Sort.Order.Direction:
+      type: string
+      enum:
+      - ASC
+      - DESC

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,23 +4,42 @@ plugins {
     id("io.micronaut.platform.catalog") version "5.0.2"
 }
 
+// Both onelitefeather.dev repos below share one account - read the same
+// OneLiteFeatherRepositoryUsername/Password gradle properties (or CI env vars) for each,
+// rather than each repo's own name-derived credential convention, so only one set of
+// credentials needs to be configured locally/in CI.
+fun org.gradle.api.artifacts.repositories.MavenArtifactRepository.oneLiteFeatherCredentials() {
+    if (System.getenv("CI") != null) {
+        credentials {
+            username = System.getenv("ONELITEFEATHER_MAVEN_USERNAME")
+            password = System.getenv("ONELITEFEATHER_MAVEN_PASSWORD")
+        }
+    } else {
+        credentials {
+            username = providers.gradleProperty("OneLiteFeatherRepositoryUsername").orNull
+            password = providers.gradleProperty("OneLiteFeatherRepositoryPassword").orNull
+        }
+        authentication {
+            create<BasicAuthentication>("basic")
+        }
+    }
+}
+
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
         maven {
             name = "OneLiteFeatherRepository"
             url = uri("https://repo.onelitefeather.dev/onelitefeather")
-            if (System.getenv("CI") != null) {
-                credentials {
-                    username = System.getenv("ONELITEFEATHER_MAVEN_USERNAME")
-                    password = System.getenv("ONELITEFEATHER_MAVEN_PASSWORD")
-                }
-            } else {
-                credentials(PasswordCredentials::class)
-                authentication {
-                    create<BasicAuthentication>("basic")
-                }
-            }
+            oneLiteFeatherCredentials()
+        }
+        // The aggregate "onelitefeather" repo above doesn't resolve artifacts published straight
+        // to the underlying releases/snapshots repos (e.g. Otis's otis-client - see Otis's own
+        // build.gradle.kts publishing block) - declare those explicitly too, same credentials.
+        maven {
+            name = "OneLiteFeatherReleasesRepository"
+            url = uri("https://repo.onelitefeather.dev/onelitefeather-releases")
+            oneLiteFeatherCredentials()
         }
         maven("https://repo.papermc.io/repository/maven-public/")
     }

--- a/velocity/src/main/java/net/onelitefeather/blackhole/velocity/command/PunishCommand.java
+++ b/velocity/src/main/java/net/onelitefeather/blackhole/velocity/command/PunishCommand.java
@@ -5,12 +5,14 @@ import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import net.kyori.adventure.text.Component;
+import net.onelitefeather.blackhole.client.api.PlayerApi;
 import net.onelitefeather.blackhole.client.api.PunishProfileApi;
 import net.onelitefeather.blackhole.client.api.PunishmentApi;
 import net.onelitefeather.blackhole.client.api.PunishmentTemplatesApi;
 import net.onelitefeather.blackhole.client.invoker.ApiClient;
 import net.onelitefeather.blackhole.client.invoker.ApiException;
 import net.onelitefeather.blackhole.client.model.Pageable;
+import net.onelitefeather.blackhole.client.model.PlayerResolveResponse;
 import net.onelitefeather.blackhole.client.model.PunishProfileDTO;
 import net.onelitefeather.blackhole.client.model.PunishTemplateDTO;
 import net.onelitefeather.blackhole.client.model.PunishType;
@@ -24,21 +26,33 @@ import org.incendo.cloud.context.CommandContext;
 import org.incendo.cloud.context.CommandInput;
 import org.incendo.cloud.key.CloudKey;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public final class PunishCommand {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PunishCommand.class);
-    static final CloudKey<Player> TARGET_KEY = CloudKey.of("target", Player.class);
+    static final CloudKey<ResolvedTarget> TARGET_KEY = CloudKey.of("target", ResolvedTarget.class);
+
+    /**
+     * A punishment target resolved either from a currently-connected {@link Player} or, if they
+     * aren't online, from the backend's player-resolver chain (Otis/Mojang/NameMC) - see
+     * {@link #parseProfile}. {@code onlinePlayer} is {@code null} for an offline target; callers
+     * must not disconnect/message a player directly in that case.
+     */
+    public record ResolvedTarget(UUID uuid, String name, @Nullable Player onlinePlayer) {
+    }
 
     private final ProxyServer proxyServer;
     private final PunishProfileApi punishProfileApi;
     private final PunishmentApi punishmentApi;
     private final PunishmentTemplatesApi punishmentTemplatesApi;
+    private final PlayerApi playerApi;
 
     @Inject
     public PunishCommand(@NotNull ProxyServer proxyServer, @NotNull ApiClient apiClient) {
@@ -46,6 +60,7 @@ public final class PunishCommand {
         this.punishProfileApi = new PunishProfileApi(apiClient);
         this.punishmentApi = new PunishmentApi(apiClient);
         this.punishmentTemplatesApi = new PunishmentTemplatesApi(apiClient);
+        this.playerApi = new PlayerApi(apiClient);
     }
 
     @Command("blackhole <user> ban <template>")
@@ -54,7 +69,7 @@ public final class PunishCommand {
     @CommandDescription("Ban a player from the server")
     public void banPlayer(
             CommandContext<Player> context,
-            @Argument(value = "user", parserName = "profile") @NotNull PunishProfileDTO user,
+            @Argument(value = "user", parserName = "profile", suggestions = "players") @NotNull PunishProfileDTO user,
             @Argument(value = "template", parserName = "template") @NotNull PunishTemplateDTO template,
             @Flag("server") Boolean server
     ) {
@@ -82,10 +97,12 @@ public final class PunishCommand {
             return;
         }
 
-        Player targetPlayer = context.get(TARGET_KEY);
+        ResolvedTarget target = context.get(TARGET_KEY);
         PunishProfileDTO updatedProfile = profile.orElseThrow();
-        targetPlayer.disconnect(PunishmentTemplateComponent.of(template, updatedProfile));
-        context.sender().sendMessage(Component.translatable("punishment.success.ban").arguments(Component.text(targetPlayer.getUsername())));
+        if (target.onlinePlayer() != null) {
+            target.onlinePlayer().disconnect(PunishmentTemplateComponent.of(template, updatedProfile));
+        }
+        context.sender().sendMessage(Component.translatable("punishment.success.ban").arguments(Component.text(target.name())));
     }
 
     @Command("blackhole <user> mute <template>")
@@ -95,7 +112,7 @@ public final class PunishCommand {
     @PunishTypeScope(PunishType.CHAT)
     public void mutePlayer(
             CommandContext<Player> context,
-            @Argument(value = "user", parserName = "profile") @NotNull PunishProfileDTO user,
+            @Argument(value = "user", parserName = "profile", suggestions = "players") @NotNull PunishProfileDTO user,
             @Argument(value = "template", parserName = "template") @NotNull PunishTemplateDTO template
     ) {
         if (template.getIdentifier() == null) {
@@ -124,19 +141,43 @@ public final class PunishCommand {
     @Parser(name = "profile")
     public PunishProfileDTO parseProfile(CommandContext<CommandSource> context, CommandInput input) {
         String name = input.readString();
-        Optional<Player> player = this.proxyServer.getPlayer(name);
+        Optional<Player> onlinePlayer = this.proxyServer.getPlayer(name);
 
-        if (player.isEmpty()) {
-            throw new IllegalArgumentException("Player(%s) not found".formatted(name));
+        UUID uuid;
+        String resolvedName;
+        if (onlinePlayer.isPresent()) {
+            uuid = onlinePlayer.get().getUniqueId();
+            resolvedName = onlinePlayer.get().getUsername();
+        } else {
+            // Not connected right now - fall back to the backend's resolver chain (Otis/Mojang/
+            // NameMC) so offline players can still be targeted; enforcement itself is already
+            // UUID-driven at login (PlayerLoginListener), so nothing further is needed here.
+            PlayerResolveResponse resolved;
+            try {
+                resolved = this.playerApi.resolvePlayer(name);
+            } catch (ApiException e) {
+                throw new IllegalArgumentException("Player(%s) not found".formatted(name));
+            }
+            uuid = resolved.getUuid();
+            resolvedName = resolved.getName();
         }
-        context.store(TARGET_KEY, player.get());
+        context.store(TARGET_KEY, new ResolvedTarget(uuid, resolvedName, onlinePlayer.orElse(null)));
 
         try {
-            return this.punishProfileApi.getById(UUIDConverter.convertToSHA(player.get().getUniqueId()));
+            return this.punishProfileApi.getById(UUIDConverter.convertToSHA(uuid));
         } catch (ApiException e) {
             LOGGER.error("Failed to fetch punish profile for player {}: {}", name, e.getMessage());
             return null;
         }
+    }
+
+    @Suggestions("players")
+    public List<String> suggestPlayers(CommandContext<Player> context, CommandInput input) {
+        String prefix = input.readString();
+        return this.proxyServer.getAllPlayers().stream()
+                .map(Player::getUsername)
+                .filter(username -> username.toLowerCase().startsWith(prefix.toLowerCase()))
+                .toList();
     }
 
     @Parser(suggestions = "templates", name = "template")

--- a/velocity/src/main/java/net/onelitefeather/blackhole/velocity/command/PunishInfoCommand.java
+++ b/velocity/src/main/java/net/onelitefeather/blackhole/velocity/command/PunishInfoCommand.java
@@ -17,9 +17,9 @@ public final class PunishInfoCommand {
     @Command("blackhole <user> info")
     @Permission("blackhole.user.info")
     @CommandDescription("Get information about a player's ban")
-    public void userInfo(@NotNull CommandContext<Player> context, @Argument(value = "user", parserName = "profile") PunishProfileDTO user) {
-        Player targetPlayer = context.get(PunishCommand.TARGET_KEY);
-        Component punishInfo = PunishProfileComponents.componentRepresentation(targetPlayer.getUsername(), user);
+    public void userInfo(@NotNull CommandContext<Player> context, @Argument(value = "user", parserName = "profile", suggestions = "players") PunishProfileDTO user) {
+        PunishCommand.ResolvedTarget target = context.get(PunishCommand.TARGET_KEY);
+        Component punishInfo = PunishProfileComponents.componentRepresentation(target.name(), user);
 
         context.sender().sendMessage(punishInfo);
     }
@@ -27,10 +27,10 @@ public final class PunishInfoCommand {
     @Command("blackhole <user> history <sort>")
     @Permission("blackhole.ban.history")
     @CommandDescription("Get the ban history of a player")
-    public void banHistory(@NotNull CommandContext<Player> context, @Argument(value = "user", parserName = "profile") PunishProfileDTO user, @Argument("sort") String sort) {
-        Player targetPlayer = context.get(PunishCommand.TARGET_KEY);
+    public void banHistory(@NotNull CommandContext<Player> context, @Argument(value = "user", parserName = "profile", suggestions = "players") PunishProfileDTO user, @Argument("sort") String sort) {
+        PunishCommand.ResolvedTarget target = context.get(PunishCommand.TARGET_KEY);
 
-        Component history = PunishProfileComponents.historyRepresentation(targetPlayer.getUsername(), user);
+        Component history = PunishProfileComponents.historyRepresentation(target.name(), user);
         context.sender().sendMessage(history);
     }
 }


### PR DESCRIPTION
## Summary
- Moderators could previously only `/ban`/`/mute` a player who was online right now - the `user` command argument had no tab completion at all, and offline names failed outright. Punishment enforcement is already fully UUID-driven at login, so the missing piece was name-to-UUID resolution.
- Adds a backend `GET /player/resolve/{name}` endpoint backed by an ordered, pluggable `PlayerResolver` chain: Otis (the team's own player master-data service, via its published `otis-client`), then Mojang's official API, then a best-effort NameMC lookup (no official API exists, so this is HTML-scraped and **disabled by default**). Each resolver is independently toggleable via new `blackhole.player-resolver.*` config.
- `PunishCommand` now suggests online player names as you type (`@Suggestions`) and falls back to the resolver chain for offline targets on submit. A new `ResolvedTarget` record replaces the old `Player`-typed `TARGET_KEY` so an offline target can be represented (null online `Player`) - `banPlayer` skips the disconnect-kick for offline targets but still records the punishment, enforced on next login via the existing, unchanged `PlayerLoginListener`. `PunishInfoCommand` picked up the same tab completion.
- New DTO (`PlayerResolveDTO`), service (`PlayerLookupService`), and controller (`PlayerLookupController`/`PlayerLookupApi`) follow this repo's controller/service/dto-contract/openapi-contract layering conventions - `PlayerResolveDTO` is the first DTO in the repo to use the sealed-interface Response/Error pattern.
- Bumped the pinned client OpenAPI spec to `blackhole-api-0.0.8.yml` and regenerated the `client` module.
- Added `backend/src/test/.../playerresolver/PlayerResolverServiceTest.java` - the first unit test in this repo - covering resolver-chain ordering, fallthrough, fail-soft behavior on a throwing resolver, and cache hit-once behavior.

## Known gap / test plan
- [ ] `:client:openApiGenerate` regenerates cleanly with the new `PlayerApi`/`PlayerResolveResponse` (verified locally)
- [ ] `:velocity:compileJava` builds successfully against the regenerated client (verified locally)
- [ ] `:backend:compileJava`/`:backend:build` - **not verified in the dev sandbox this PR was authored in**, since it lacked working read credentials for `repo.onelitefeather.dev` where `net.onelitefeather.otis:otis-client:1.16.0` is published (settings.gradle.kts previously only had that repo wired for publishing, not as a resolvable dependency source - added an explicit `onelitefeather-releases` repo entry alongside the existing aggregate one, sharing the same credentials). Every method/field `OtisPlayerResolver` calls was cross-checked directly against Otis's real generated sources, but please run the full build with real credentials (or let CI do it) before merging.
- [ ] Manual runtime check: `/ban <offlineName> <template>` against a real backend + Velocity instance, confirming the moderator gets a success message, the profile gets an active ban, and the player is kicked on next login.