### PR TITLE
refactor(backend): extract EloQueryService methods for EloController reads

### DIFF
--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/elo/controller/EloController.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/elo/controller/EloController.java
@@ -1,15 +1,14 @@
 package net.onelitefeather.blackhole.backend.elo.controller;
 
 import net.onelitefeather.blackhole.backend.elo.EloEventEntity;
-import net.onelitefeather.blackhole.backend.elo.EloEventRepository;
 import net.onelitefeather.blackhole.backend.elo.EloProfileEntity;
-import net.onelitefeather.blackhole.backend.elo.EloProfileRepository;
 import net.onelitefeather.blackhole.backend.elo.ToxicityScorer;
 import net.onelitefeather.blackhole.backend.elo.dto.ChatSignalDTO;
 import net.onelitefeather.blackhole.backend.elo.dto.ChatToxicityResult;
 import net.onelitefeather.blackhole.backend.elo.dto.EloEventDTO;
 import net.onelitefeather.blackhole.backend.elo.dto.EloProfileDTO;
 import net.onelitefeather.blackhole.backend.elo.service.ChatToxicityService;
+import net.onelitefeather.blackhole.backend.elo.service.EloService;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.http.HttpResponse;
@@ -39,18 +38,15 @@ import net.onelitefeather.blackhole.backend.controller.ApiVersion;
 public class EloController {
 
     private final ChatToxicityService chatToxicityService;
-    private final EloProfileRepository profileRepository;
-    private final EloEventRepository eventRepository;
+    private final EloService eloService;
 
     @Inject
     public EloController(
             ChatToxicityService chatToxicityService,
-            EloProfileRepository profileRepository,
-            EloEventRepository eventRepository
+            EloService eloService
     ) {
         this.chatToxicityService = chatToxicityService;
-        this.profileRepository = profileRepository;
-        this.eventRepository = eventRepository;
+        this.eloService = eloService;
     }
 
     @Operation(
@@ -85,7 +81,7 @@ public class EloController {
     @ApiResponse(responseCode = "404", description = "No ELO profile exists yet for this owner")
     @Get("/{owner}")
     public HttpResponse<EloProfileDTO> getProfile(String owner) {
-        EloProfileEntity profile = this.profileRepository.findById(owner).orElse(null);
+        EloProfileEntity profile = this.eloService.getProfile(owner).orElse(null);
         if (profile == null) {
             return HttpResponse.notFound();
         }
@@ -108,7 +104,7 @@ public class EloController {
     )
     @Get("/{owner}/history")
     public HttpResponse<Page<EloEventDTO>> getHistory(String owner, Pageable pageable) {
-        Page<EloEventEntity> entries = this.eventRepository.findByOwner(owner, pageable);
+        Page<EloEventEntity> entries = this.eloService.getHistory(owner, pageable);
         return HttpResponse.ok(entries.map(EloEventEntity::toDTO));
     }
 }

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/elo/service/EloService.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/elo/service/EloService.java
@@ -8,6 +8,8 @@ import net.onelitefeather.blackhole.backend.elo.EloProfileRepository;
 import net.onelitefeather.blackhole.backend.elo.EloReasonCode;
 import net.onelitefeather.blackhole.backend.elo.EloTrack;
 import io.micronaut.context.annotation.Value;
+import io.micronaut.data.model.Page;
+import io.micronaut.data.model.Pageable;
 import jakarta.inject.Singleton;
 import net.onelitefeather.blackhole.backend.events.DomainEventPublisher;
 import net.onelitefeather.blackhole.backend.punishment.service.PunishmentApplicationService;
@@ -21,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -292,5 +295,26 @@ public class EloService {
             case CHAT -> "Automatic chat timeout (ELO system)";
             case GAMEPLAY -> "Automatic temporary ban (ELO system, gameplay)";
         };
+    }
+
+    /**
+     * Dashboard read: a player's current ELO standing, if any.
+     *
+     * @param owner the SHA-512-hashed owner
+     * @return the profile, or empty if none exists yet for this owner
+     */
+    public Optional<EloProfileEntity> getProfile(String owner) {
+        return this.profileRepository.findById(owner);
+    }
+
+    /**
+     * Dashboard read: the full audit trail of ELO changes for this owner.
+     *
+     * @param owner    the SHA-512-hashed owner
+     * @param pageable pagination/sorting parameters
+     * @return the paginated event history
+     */
+    public Page<EloEventEntity> getHistory(String owner, Pageable pageable) {
+        return this.eventRepository.findByOwner(owner, pageable);
     }
 }


### PR DESCRIPTION
## Summary
- `EloController` injected `EloProfileRepository`/`EloEventRepository` directly for its two read endpoints, bypassing the service layer — the one documented layering gap in `specs/001-elo-engine/plan.md`'s Constitution Check (Principle III, PARTIAL).
- Moves `getProfile`/`getHistory` onto `EloService`, which already owns both repositories for its write path.
- Pure refactor — no API/response-shape change.

## Test plan
- [x] `./gradlew :backend:compileJava` succeeds
- [x] Verified against real Docker infra: 404 for unknown owner, chat-toxicity flag → profile reflects the delta, history returns the event — identical to pre-refactor behavior