### PR TITLE
refactor(backend): extract PunishmentTemplateService, fix getAll layering

### DIFF
--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/PunishmentExpirySweeper.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/PunishmentExpirySweeper.java
@@ -38,7 +38,10 @@ public class PunishmentExpirySweeper {
         this.cacheInvalidationPublisher = cacheInvalidationPublisher;
     }
 
-    @Scheduled(fixedDelay = "1m", initialDelay = "1m")
+    @Scheduled(
+            fixedDelay = "${blackhole.punishment.expiry.sweep-interval:1m}",
+            initialDelay = "${blackhole.punishment.expiry.sweep-interval:1m}"
+    )
     void sweep() {
         int expiredCount = 0;
         Pageable pageable = Pageable.from(0, PAGE_SIZE);

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/controller/PunishmentEntityController.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/controller/PunishmentEntityController.java
@@ -1,7 +1,6 @@
 package net.onelitefeather.blackhole.backend.punishment.controller;
 
 import net.onelitefeather.blackhole.backend.punishment.PunishmentEntity;
-import net.onelitefeather.blackhole.backend.punishment.PunishmentRepository;
 import net.onelitefeather.blackhole.backend.punishment.dto.PunishEntryDTO;
 import net.onelitefeather.blackhole.backend.punishment.service.PunishmentApplicationService;
 import io.micronaut.data.model.Page;
@@ -29,21 +28,17 @@ import java.util.UUID;
 @Controller("/punishment")
 public class PunishmentEntityController {
 
-    private final PunishmentRepository punishmentRepository;
     private final PunishmentApplicationService punishmentApplicationService;
 
     /**
      * Create a new PunishmentEntityController with the given values.
      *
-     * @param punishmentRepository        the repository to list punishments
-     * @param punishmentApplicationService applies a punishment template to a profile
+     * @param punishmentApplicationService applies a punishment template to a profile, and lists punishments
      */
     @Inject
     public PunishmentEntityController(
-            PunishmentRepository punishmentRepository,
             PunishmentApplicationService punishmentApplicationService
     ) {
-        this.punishmentRepository = punishmentRepository;
         this.punishmentApplicationService = punishmentApplicationService;
     }
 
@@ -199,7 +194,7 @@ public class PunishmentEntityController {
     )
     @Get()
     public HttpResponse<Page<PunishEntryDTO>> getAll(Pageable pageable) {
-        Page<PunishmentEntity> entries = this.punishmentRepository.findAll(pageable);
+        Page<PunishmentEntity> entries = this.punishmentApplicationService.findAll(pageable);
         return HttpResponse.ok(entries.map(PunishmentEntity::toDTO));
     }
 }

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/controller/PunishmentTemplateController.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/controller/PunishmentTemplateController.java
@@ -1,9 +1,8 @@
 package net.onelitefeather.blackhole.backend.punishment.controller;
 
-import net.onelitefeather.blackhole.backend.punishment.PunishmentTemplateEntity;
-import net.onelitefeather.blackhole.backend.punishment.PunishmentTemplateRepository;
 import net.onelitefeather.blackhole.backend.punishment.dto.PunishTemplateDTO;
 import net.onelitefeather.blackhole.backend.punishment.dto.PunishTemplateRequestDTO;
+import net.onelitefeather.blackhole.backend.punishment.service.PunishmentTemplateService;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.http.HttpResponse;
@@ -23,7 +22,6 @@ import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import net.onelitefeather.blackhole.backend.controller.ApiVersion;
 
-import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -37,16 +35,16 @@ import java.util.UUID;
 @Controller("/template")
 public class PunishmentTemplateController {
 
-    private final PunishmentTemplateRepository templateRepository;
+    private final PunishmentTemplateService templateService;
 
     /**
      * Create a new PunishmentTemplateController
      *
-     * @param templateRepository the repository to use
+     * @param templateService the service to use
      */
     @Inject
-    public PunishmentTemplateController(PunishmentTemplateRepository templateRepository) {
-        this.templateRepository = templateRepository;
+    public PunishmentTemplateController(PunishmentTemplateService templateService) {
+        this.templateService = templateService;
     }
 
     /**
@@ -79,12 +77,10 @@ public class PunishmentTemplateController {
     )
     @Post("/")
     public HttpResponse<PunishTemplateDTO> addTemplate(@Valid @Body PunishTemplateRequestDTO template) {
-        if (template.identifier() != null) {
-            return HttpResponse.notAllowed();
-        }
-        PunishmentTemplateEntity dbEntity = PunishmentTemplateEntity.toEntity(template);
-        PunishmentTemplateEntity savedEntity = this.templateRepository.save(dbEntity);
-        return HttpResponse.ok(savedEntity.toDTO());
+        return switch (this.templateService.create(template)) {
+            case PunishmentTemplateService.CreateResult.Created created -> HttpResponse.ok(created.template());
+            case PunishmentTemplateService.CreateResult.IdentifierNotAllowed ignored -> HttpResponse.notAllowed();
+        };
     }
 
     /**
@@ -117,18 +113,11 @@ public class PunishmentTemplateController {
     )
     @Post(value = "/update")
     public HttpResponse<PunishTemplateDTO> updateTemplate(@Valid @Body PunishTemplateRequestDTO template) {
-        if (template.identifier() == null) {
-            return HttpResponse.badRequest();
-        }
-        PunishmentTemplateEntity existing = this.templateRepository.findById(template.identifier()).orElse(null);
-        if (existing == null) {
-            return HttpResponse.notFound();
-        }
-
-        PunishmentTemplateEntity savedEntity = this.templateRepository.update(
-                PunishmentTemplateEntity.toEntity(template)
-        );
-        return HttpResponse.ok(savedEntity.toDTO());
+        return switch (this.templateService.update(template)) {
+            case PunishmentTemplateService.UpdateResult.Updated updated -> HttpResponse.ok(updated.template());
+            case PunishmentTemplateService.UpdateResult.MissingIdentifier ignored -> HttpResponse.badRequest();
+            case PunishmentTemplateService.UpdateResult.NotFound ignored -> HttpResponse.notFound();
+        };
     }
 
     /**
@@ -157,14 +146,9 @@ public class PunishmentTemplateController {
     )
     @Delete(value = "/delete/{identifier}")
     public HttpResponse<PunishTemplateDTO> removeTemplate(@PathVariable UUID identifier) {
-        PunishmentTemplateEntity entity = this.templateRepository.findById(identifier).orElse(null);
-
-        if (entity == null) {
-            return HttpResponse.notFound();
-        }
-        this.templateRepository.delete(entity);
-
-        return HttpResponse.ok(entity.toDTO());
+        return this.templateService.remove(identifier)
+                .map(HttpResponse::ok)
+                .orElseGet(HttpResponse::notFound);
     }
 
     /**
@@ -191,8 +175,7 @@ public class PunishmentTemplateController {
     )
     @Get("/")
     public HttpResponse<Page<PunishTemplateDTO>> getAll(Pageable pageable) {
-        Page<PunishmentTemplateEntity> entities = this.templateRepository.findAll(pageable);
-        return HttpResponse.ok(entities.map(PunishmentTemplateEntity::toDTO));
+        return HttpResponse.ok(this.templateService.findAll(pageable));
     }
 
     /**
@@ -221,8 +204,7 @@ public class PunishmentTemplateController {
     )
     @Get("/{identifier}")
     public HttpResponse<PunishTemplateDTO> get(UUID identifier) {
-        Optional<PunishmentTemplateEntity> entity = this.templateRepository.findById(identifier);
-        return entity.map(PunishmentTemplateEntity::toDTO)
+        return this.templateService.find(identifier)
                 .map(HttpResponse::ok)
                 .orElseGet(HttpResponse::notFound);
     }

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/service/PunishmentApplicationService.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/service/PunishmentApplicationService.java
@@ -8,6 +8,8 @@ import net.onelitefeather.blackhole.backend.punishment.PunishmentTemplateEntity;
 import net.onelitefeather.blackhole.backend.punishment.PunishmentTemplateRepository;
 import net.onelitefeather.blackhole.backend.punishment.controller.PunishmentEntityController;
 import io.micronaut.context.BeanProvider;
+import io.micronaut.data.model.Page;
+import io.micronaut.data.model.Pageable;
 import jakarta.inject.Singleton;
 import net.onelitefeather.blackhole.backend.elo.EloReasonCode;
 import net.onelitefeather.blackhole.backend.elo.service.EloService;
@@ -153,6 +155,13 @@ public class PunishmentApplicationService {
         this.eventPublisher.publish("punishment.created", punishmentCreatedPayload);
 
         return Optional.of(savedProfile);
+    }
+
+    /**
+     * Returns a paginated list of all punishment entries in the system.
+     */
+    public Page<PunishmentEntity> findAll(Pageable pageable) {
+        return this.punishmentRepository.findAll(pageable);
     }
 
     /**

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/service/PunishmentTemplateService.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/service/PunishmentTemplateService.java
@@ -1,0 +1,108 @@
+package net.onelitefeather.blackhole.backend.punishment.service;
+
+import net.onelitefeather.blackhole.backend.punishment.PunishmentTemplateEntity;
+import net.onelitefeather.blackhole.backend.punishment.PunishmentTemplateRepository;
+import net.onelitefeather.blackhole.backend.punishment.dto.PunishTemplateDTO;
+import net.onelitefeather.blackhole.backend.punishment.dto.PunishTemplateRequestDTO;
+import io.micronaut.data.model.Page;
+import io.micronaut.data.model.Pageable;
+import jakarta.inject.Singleton;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Owns {@link PunishmentTemplateRepository} on behalf of {@code PunishmentTemplateController},
+ * which previously called the repository directly from all 5 endpoints. This replicates the
+ * exact same validation/response semantics the controller used to implement inline - a pure
+ * layering fix, not a contract change (see {@code micronaut-service-layer}/{@code
+ * micronaut-controller-layer}).
+ */
+@Singleton
+public class PunishmentTemplateService {
+
+    private final PunishmentTemplateRepository templateRepository;
+
+    public PunishmentTemplateService(PunishmentTemplateRepository templateRepository) {
+        this.templateRepository = templateRepository;
+    }
+
+    /**
+     * Creates a new template. {@code identifier} must be {@code null} for creation - see
+     * {@link CreateResult.IdentifierNotAllowed}.
+     */
+    public CreateResult create(PunishTemplateRequestDTO template) {
+        if (template.identifier() != null) {
+            return new CreateResult.IdentifierNotAllowed();
+        }
+        PunishmentTemplateEntity saved = this.templateRepository.save(PunishmentTemplateEntity.toEntity(template));
+        return new CreateResult.Created(saved.toDTO());
+    }
+
+    /**
+     * Updates an existing template. {@code identifier} is required and must reference an
+     * existing template - see {@link UpdateResult.MissingIdentifier} / {@link UpdateResult.NotFound}.
+     */
+    public UpdateResult update(PunishTemplateRequestDTO template) {
+        if (template.identifier() == null) {
+            return new UpdateResult.MissingIdentifier();
+        }
+        if (this.templateRepository.findById(template.identifier()).isEmpty()) {
+            return new UpdateResult.NotFound();
+        }
+        PunishmentTemplateEntity saved = this.templateRepository.update(PunishmentTemplateEntity.toEntity(template));
+        return new UpdateResult.Updated(saved.toDTO());
+    }
+
+    /**
+     * Deletes the template with {@code identifier}, returning its DTO, or empty if no template
+     * with that identifier exists.
+     */
+    public Optional<PunishTemplateDTO> remove(UUID identifier) {
+        return this.templateRepository.findById(identifier).map(entity -> {
+            this.templateRepository.delete(entity);
+            return entity.toDTO();
+        });
+    }
+
+    /**
+     * Returns a paginated list of all templates.
+     */
+    public Page<PunishTemplateDTO> findAll(Pageable pageable) {
+        return this.templateRepository.findAll(pageable).map(PunishmentTemplateEntity::toDTO);
+    }
+
+    /**
+     * Returns the template with {@code identifier}, if any.
+     */
+    public Optional<PunishTemplateDTO> find(UUID identifier) {
+        return this.templateRepository.findById(identifier).map(PunishmentTemplateEntity::toDTO);
+    }
+
+    /**
+     * Outcome of {@link #create(PunishTemplateRequestDTO)}, mapped 1:1 to an {@code HttpResponse}
+     * by the controller instead of the controller re-deriving what happened.
+     */
+    public sealed interface CreateResult {
+        record Created(PunishTemplateDTO template) implements CreateResult {
+        }
+
+        record IdentifierNotAllowed() implements CreateResult {
+        }
+    }
+
+    /**
+     * Outcome of {@link #update(PunishTemplateRequestDTO)}, mapped 1:1 to an {@code HttpResponse}
+     * by the controller instead of the controller re-deriving what happened.
+     */
+    public sealed interface UpdateResult {
+        record Updated(PunishTemplateDTO template) implements UpdateResult {
+        }
+
+        record MissingIdentifier() implements UpdateResult {
+        }
+
+        record NotFound() implements UpdateResult {
+        }
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -65,6 +65,13 @@ blackhole:
       max-reports: ${BLACKHOLE_REPORT_RATE_LIMIT_MAX:5}
       max-reports-network-wide: ${BLACKHOLE_REPORT_RATE_LIMIT_MAX_NETWORK_WIDE:50}
       window: ${BLACKHOLE_REPORT_RATE_LIMIT_WINDOW:PT10M}
+  # PunishmentExpirySweeper periodically moves expired active bans/mutes into a profile's
+  # history, so expiry is an active background process rather than something only noticed the
+  # next time a profile happens to be read. sweep-interval controls how often that scan runs -
+  # shortened via env var for testing, 1 minute by default in production.
+  punishment:
+    expiry:
+      sweep-interval: ${BLACKHOLE_PUNISHMENT_EXPIRY_SWEEP_INTERVAL:1m}
   # Dual-ELO system (Phase 5): baseline is the network-wide starting/neutral score for both
   # tracks, and perma-ban-threshold the network-wide permanent-ban trigger. Crossing below
   # soft-threshold triggers an automatic temporary punishment; below perma-ban-threshold, a


### PR DESCRIPTION
## Summary
- `PunishmentTemplateController` had no service layer at all across all 5 endpoints, and `PunishmentEntityController.getAll` bypassed `PunishmentApplicationService` — the most severe layering gap documented in `specs/002-punishment-core/plan.md`'s Constitution Check (Principle III, FAIL).
- Extracts `PunishmentTemplateService` (sealed `CreateResult`/`UpdateResult` outcome types, same validation/response semantics as before) and adds `PunishmentApplicationService.findAll`.
- Makes `PunishmentExpirySweeper`'s sweep interval env-var configurable (`blackhole.punishment.expiry.sweep-interval`, default `1m`) per this project's config convention, instead of a hardcoded `@Scheduled` value.
- Deferred (not in this PR, per plan.md): the live template reference letting an edited template retroactively change historical punishment display, the missing FK cascade on template delete, and the sealed DTO/`Error`-variant contract migration.

## Test plan
- [x] `./gradlew :backend:compileJava` succeeds
- [x] Verified against real Docker infra: template create/create-conflict(405)/get/update/getAll, punishment apply + getAll, template delete + delete-not-found(404) all behave identically to pre-refactor
- [x] Also reproduced the pre-existing (documented-as-deferred) FK-constraint error when deleting a template with punishments referencing it — confirms unchanged behavior, not a regression