### PR TITLE
refactor(backend): extract appeal review logic into AppealDecisionService

### DIFF
--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/appeal/AppealReviewResult.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/appeal/AppealReviewResult.java
@@ -1,0 +1,66 @@
+package net.onelitefeather.blackhole.backend.appeal;
+
+/**
+ * The outcome of {@code AppealDecisionService.reviewAppeal} - every rejection reason the review
+ * endpoint can hit, plus the decided appeal on success, so {@code AppealController} only has to
+ * map this 1:1 onto an {@code HttpResponse} rather than re-deriving why a review was rejected.
+ *
+ * @param kind    which outcome this is
+ * @param message the human-readable rejection reason; {@code null} for {@link Kind#NOT_FOUND}
+ *                and {@link Kind#DECIDED}
+ * @param appeal  the updated, saved appeal; only present for {@link Kind#DECIDED}
+ */
+public record AppealReviewResult(Kind kind, String message, AppealEntity appeal) {
+
+    public enum Kind {
+        NOT_FOUND,
+        NOT_AWAITING_REVIEW,
+        INVALID_DECISION,
+        SELF_REVIEW,
+        SEVERE_FULL_LIFT_DISALLOWED,
+        DURATION_REDUCTION_MISSING_EXPIRY,
+        DURATION_REDUCTION_EXPIRY_NOT_FUTURE,
+        PUNISHMENT_NOT_ACTIVE,
+        DECIDED
+    }
+
+    public static AppealReviewResult notFound() {
+        return new AppealReviewResult(Kind.NOT_FOUND, null, null);
+    }
+
+    public static AppealReviewResult notAwaitingReview() {
+        return new AppealReviewResult(Kind.NOT_AWAITING_REVIEW, "Appeal is not awaiting review", null);
+    }
+
+    public static AppealReviewResult invalidDecision(String message) {
+        return new AppealReviewResult(Kind.INVALID_DECISION, message, null);
+    }
+
+    public static AppealReviewResult selfReview() {
+        return new AppealReviewResult(Kind.SELF_REVIEW, "Reviewer must not be the punishment's original source", null);
+    }
+
+    public static AppealReviewResult severeFullLiftDisallowed() {
+        return new AppealReviewResult(
+                Kind.SEVERE_FULL_LIFT_DISALLOWED, "SEVERE punishments can only receive a duration reduction, never a full lift", null
+        );
+    }
+
+    public static AppealReviewResult durationReductionMissingExpiry() {
+        return new AppealReviewResult(
+                Kind.DURATION_REDUCTION_MISSING_EXPIRY, "newExpirationAt is required for GRANTED_DURATION_REDUCTION", null
+        );
+    }
+
+    public static AppealReviewResult durationReductionExpiryNotFuture() {
+        return new AppealReviewResult(Kind.DURATION_REDUCTION_EXPIRY_NOT_FUTURE, "newExpirationAt must be in the future", null);
+    }
+
+    public static AppealReviewResult punishmentNotActive() {
+        return new AppealReviewResult(Kind.PUNISHMENT_NOT_ACTIVE, "Punishment is no longer active", null);
+    }
+
+    public static AppealReviewResult decided(AppealEntity appeal) {
+        return new AppealReviewResult(Kind.DECIDED, null, appeal);
+    }
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/appeal/controller/AppealController.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/appeal/controller/AppealController.java
@@ -2,9 +2,8 @@ package net.onelitefeather.blackhole.backend.appeal.controller;
 
 import net.onelitefeather.blackhole.backend.appeal.AppealEntity;
 import net.onelitefeather.blackhole.backend.appeal.AppealRepository;
+import net.onelitefeather.blackhole.backend.appeal.AppealReviewResult;
 import net.onelitefeather.blackhole.backend.appeal.AppealStatus;
-import net.onelitefeather.blackhole.backend.appeal.DecisionOutcome;
-import net.onelitefeather.blackhole.backend.appeal.EligibilityResult;
 import net.onelitefeather.blackhole.backend.appeal.dto.AppealDTO;
 import net.onelitefeather.blackhole.backend.appeal.dto.AppealReviewDTO;
 import net.onelitefeather.blackhole.backend.appeal.dto.AppealSubmissionDTO;
@@ -29,12 +28,9 @@ import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import net.onelitefeather.blackhole.backend.controller.ApiVersion;
 import net.onelitefeather.blackhole.backend.events.DomainEventPublisher;
-import net.onelitefeather.blackhole.backend.punishment.PunishmentEntity;
-import net.onelitefeather.blackhole.backend.punishment.PunishmentRepository;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -42,17 +38,15 @@ import java.util.UUID;
  * gates whether an appeal is even reviewable at all, then a human reviewer decides within what
  * the checklist allows - never pure algorithmic auto-lift (a farming vector) and never
  * unconstrained human discretion (today's original problem this whole system exists to fix).
+ * {@code AppealRepository} is only used here for the plain, read-only appeal listing - the same
+ * accepted exception {@code EloController} makes for its own read endpoints - every other
+ * repository access lives in {@link AppealEligibilityService}/{@link AppealDecisionService}.
  */
 @Version(ApiVersion.V1)
 @Controller("/appeal")
 public class AppealController {
 
-    private static final Set<AppealStatus> VALID_DECISIONS = Set.of(
-            AppealStatus.GRANTED_FULL_LIFT, AppealStatus.GRANTED_DURATION_REDUCTION, AppealStatus.DENIED
-    );
-
     private final AppealRepository appealRepository;
-    private final PunishmentRepository punishmentRepository;
     private final AppealEligibilityService eligibilityService;
     private final AppealDecisionService decisionService;
     private final DomainEventPublisher eventPublisher;
@@ -60,13 +54,11 @@ public class AppealController {
     @Inject
     public AppealController(
             AppealRepository appealRepository,
-            PunishmentRepository punishmentRepository,
             AppealEligibilityService eligibilityService,
             AppealDecisionService decisionService,
             DomainEventPublisher eventPublisher
     ) {
         this.appealRepository = appealRepository;
-        this.punishmentRepository = punishmentRepository;
         this.eligibilityService = eligibilityService;
         this.decisionService = decisionService;
         this.eventPublisher = eventPublisher;
@@ -87,29 +79,23 @@ public class AppealController {
     @Validated
     @Post("/")
     public HttpResponse<?> submit(@Body @Valid AppealSubmissionDTO submission) {
-        PunishmentEntity punishment = this.punishmentRepository.findById(submission.punishmentIdentifier()).orElse(null);
-        if (punishment == null) {
+        Optional<AppealEntity> saved = this.eligibilityService.submitAppeal(
+                submission.punishmentIdentifier(), submission.appellantHash(), submission.statement()
+        );
+        if (saved.isEmpty()) {
             return HttpResponse.notFound();
         }
 
-        EligibilityResult eligibility = this.eligibilityService.evaluate(punishment, submission.appellantHash());
-        long now = System.currentTimeMillis();
-
-        AppealEntity appeal = new AppealEntity(
-                punishment, submission.appellantHash(), submission.statement(),
-                eligibility.eligible() ? AppealStatus.ELIGIBLE_PENDING_REVIEW : AppealStatus.INELIGIBLE,
-                eligibility.checklistSnapshot(), now, now, new HashMap<>()
-        );
-        AppealEntity saved = this.appealRepository.save(appeal);
-
+        AppealEntity appeal = saved.get();
+        boolean eligible = appeal.getStatus() == AppealStatus.ELIGIBLE_PENDING_REVIEW;
         this.eventPublisher.publish("appeal.submitted", Map.of(
-                "appealIdentifier", saved.getIdentifier().toString(),
+                "appealIdentifier", appeal.getIdentifier().toString(),
                 "owner", submission.appellantHash(),
                 "punishmentIdentifier", submission.punishmentIdentifier(),
-                "eligible", eligibility.eligible()
+                "eligible", eligible
         ));
 
-        return HttpResponse.ok(saved.toDTO());
+        return HttpResponse.ok(appeal.toDTO());
     }
 
     @Operation(
@@ -151,56 +137,24 @@ public class AppealController {
     @Validated
     @Post("/{identifier}/review")
     public HttpResponse<?> review(UUID identifier, @Body @Valid AppealReviewDTO review) {
-        AppealEntity appeal = this.appealRepository.findById(identifier).orElse(null);
-        if (appeal == null) {
-            return HttpResponse.notFound();
-        }
-        if (appeal.getStatus() != AppealStatus.ELIGIBLE_PENDING_REVIEW && appeal.getStatus() != AppealStatus.IN_REVIEW) {
-            return HttpResponse.status(HttpStatus.CONFLICT, "Appeal is not awaiting review");
-        }
-        if (!VALID_DECISIONS.contains(review.decision())) {
-            return HttpResponse.badRequest("decision must be one of " + VALID_DECISIONS);
-        }
-
-        PunishmentEntity punishment = appeal.getPunishment();
-        if (review.reviewerId().equals(punishment.getSource())) {
-            return HttpResponse.status(HttpStatus.FORBIDDEN, "Reviewer must not be the punishment's original source");
-        }
-
-        boolean severe = "SEVERE".equals(appeal.getEligibilityCheckResult().get("severityTier"));
-        if (severe && review.decision() == AppealStatus.GRANTED_FULL_LIFT) {
-            return HttpResponse.badRequest("SEVERE punishments can only receive a duration reduction, never a full lift");
-        }
-        if (review.decision() == AppealStatus.GRANTED_DURATION_REDUCTION) {
-            if (review.newExpirationAt() == null) {
-                return HttpResponse.badRequest("newExpirationAt is required for GRANTED_DURATION_REDUCTION");
+        AppealReviewResult result = this.decisionService.reviewAppeal(identifier, review);
+        return switch (result.kind()) {
+            case NOT_FOUND -> HttpResponse.notFound();
+            case NOT_AWAITING_REVIEW, PUNISHMENT_NOT_ACTIVE -> HttpResponse.status(HttpStatus.CONFLICT, result.message());
+            case INVALID_DECISION, SEVERE_FULL_LIFT_DISALLOWED, DURATION_REDUCTION_MISSING_EXPIRY, DURATION_REDUCTION_EXPIRY_NOT_FUTURE ->
+                    HttpResponse.badRequest(result.message());
+            case SELF_REVIEW -> HttpResponse.status(HttpStatus.FORBIDDEN, result.message());
+            case DECIDED -> {
+                AppealEntity appeal = result.appeal();
+                this.eventPublisher.publish("appeal.resolved", Map.of(
+                        "appealIdentifier", identifier.toString(),
+                        "owner", appeal.getAppellantHash(),
+                        "punishmentIdentifier", appeal.getPunishment().getIdentifier(),
+                        "decision", review.decision().toString(),
+                        "type", appeal.getPunishment().getType().toString()
+                ));
+                yield HttpResponse.ok(appeal.toDTO());
             }
-            if (review.newExpirationAt() <= System.currentTimeMillis()) {
-                return HttpResponse.badRequest("newExpirationAt must be in the future");
-            }
-        }
-
-        DecisionOutcome outcome = this.decisionService.applyDecision(
-                punishment, appeal.getAppellantHash(), review.decision(), review.newExpirationAt()
-        );
-        if (outcome == DecisionOutcome.PUNISHMENT_NOT_ACTIVE) {
-            return HttpResponse.status(HttpStatus.CONFLICT, "Punishment is no longer active");
-        }
-
-        appeal.setStatus(review.decision());
-        appeal.setDecidedBy(review.reviewerId());
-        appeal.setDecisionNote(review.decisionNote());
-        appeal.setUpdatedAt(System.currentTimeMillis());
-        AppealEntity saved = this.appealRepository.update(appeal);
-
-        this.eventPublisher.publish("appeal.resolved", Map.of(
-                "appealIdentifier", identifier.toString(),
-                "owner", appeal.getAppellantHash(),
-                "punishmentIdentifier", punishment.getIdentifier(),
-                "decision", review.decision().toString(),
-                "type", punishment.getType().toString()
-        ));
-
-        return HttpResponse.ok(saved.toDTO());
+        };
     }
 }

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/appeal/controller/AppealController.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/appeal/controller/AppealController.java
@@ -1,7 +1,6 @@
 package net.onelitefeather.blackhole.backend.appeal.controller;
 
 import net.onelitefeather.blackhole.backend.appeal.AppealEntity;
-import net.onelitefeather.blackhole.backend.appeal.AppealRepository;
 import net.onelitefeather.blackhole.backend.appeal.AppealReviewResult;
 import net.onelitefeather.blackhole.backend.appeal.AppealStatus;
 import net.onelitefeather.blackhole.backend.appeal.dto.AppealDTO;
@@ -38,27 +37,24 @@ import java.util.UUID;
  * gates whether an appeal is even reviewable at all, then a human reviewer decides within what
  * the checklist allows - never pure algorithmic auto-lift (a farming vector) and never
  * unconstrained human discretion (today's original problem this whole system exists to fix).
- * {@code AppealRepository} is only used here for the plain, read-only appeal listing - the same
- * accepted exception {@code EloController} makes for its own read endpoints - every other
- * repository access lives in {@link AppealEligibilityService}/{@link AppealDecisionService}.
+ * No repository is injected here - all persistence access lives in
+ * {@link AppealEligibilityService}/{@link AppealDecisionService}, including the plain, read-only
+ * appeal listing.
  */
 @Version(ApiVersion.V1)
 @Controller("/appeal")
 public class AppealController {
 
-    private final AppealRepository appealRepository;
     private final AppealEligibilityService eligibilityService;
     private final AppealDecisionService decisionService;
     private final DomainEventPublisher eventPublisher;
 
     @Inject
     public AppealController(
-            AppealRepository appealRepository,
             AppealEligibilityService eligibilityService,
             AppealDecisionService decisionService,
             DomainEventPublisher eventPublisher
     ) {
-        this.appealRepository = appealRepository;
         this.eligibilityService = eligibilityService;
         this.decisionService = decisionService;
         this.eventPublisher = eventPublisher;
@@ -114,7 +110,7 @@ public class AppealController {
     )
     @Get("/")
     public HttpResponse<Page<AppealDTO>> getAll(Pageable pageable) {
-        Page<AppealEntity> entities = this.appealRepository.findAll(pageable);
+        Page<AppealEntity> entities = this.eligibilityService.findAll(pageable);
         return HttpResponse.ok(entities.map(AppealEntity::toDTO));
     }
 

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/appeal/service/AppealDecisionService.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/appeal/service/AppealDecisionService.java
@@ -1,7 +1,11 @@
 package net.onelitefeather.blackhole.backend.appeal.service;
 
+import net.onelitefeather.blackhole.backend.appeal.AppealEntity;
+import net.onelitefeather.blackhole.backend.appeal.AppealRepository;
+import net.onelitefeather.blackhole.backend.appeal.AppealReviewResult;
 import net.onelitefeather.blackhole.backend.appeal.AppealStatus;
 import net.onelitefeather.blackhole.backend.appeal.DecisionOutcome;
+import net.onelitefeather.blackhole.backend.appeal.dto.AppealReviewDTO;
 import jakarta.inject.Singleton;
 import net.onelitefeather.blackhole.backend.profile.CacheInvalidationPublisher;
 import net.onelitefeather.blackhole.backend.profile.PunishmentProfileEntity;
@@ -11,26 +15,99 @@ import net.onelitefeather.blackhole.backend.punishment.PunishmentRepository;
 import net.onelitefeather.phoca.metadata.Expirable;
 import net.onelitefeather.phoca.metadata.Metadata;
 
+import java.util.Set;
+import java.util.UUID;
+
 /**
- * The mechanics of actually granting an appeal - lifting a punishment early or shortening it.
- * {@code PunishmentApplicationService} only knows how to apply new punishments; reversing one
- * that's already active is a distinct operation this service owns instead.
+ * The mechanics of actually granting an appeal - lifting a punishment early or shortening it -
+ * plus everything the review endpoint needs to decide whether a decision is even allowed
+ * ({@link #reviewAppeal}). {@code PunishmentApplicationService} only knows how to apply new
+ * punishments; reversing one that's already active is a distinct operation this service owns
+ * instead.
+ *
+ * <p><b>Known limitation (deferred, not fixed here):</b> {@link #reviewAppeal}'s
+ * read-modify-write of the punishment/profile and its subsequent {@code appealRepository.update}
+ * marking the appeal decided are not atomic - {@code @Transactional} is unusable in this
+ * codebase (see {@code EloService}'s class Javadoc for why). A crash between the two would leave
+ * the punishment revoked/reduced but the appeal still {@code ELIGIBLE_PENDING_REVIEW}, or vice
+ * versa. This is an accepted race window in the same spirit as the one already documented for
+ * {@code EloService}, not newly introduced here.</p>
  */
 @Singleton
 public class AppealDecisionService {
 
+    private static final Set<AppealStatus> VALID_DECISIONS = Set.of(
+            AppealStatus.GRANTED_FULL_LIFT, AppealStatus.GRANTED_DURATION_REDUCTION, AppealStatus.DENIED
+    );
+
+    private final AppealRepository appealRepository;
     private final PunishmentRepository punishmentRepository;
     private final PunishmentProfileRepository profileRepository;
     private final CacheInvalidationPublisher cacheInvalidationPublisher;
 
     public AppealDecisionService(
+            AppealRepository appealRepository,
             PunishmentRepository punishmentRepository,
             PunishmentProfileRepository profileRepository,
             CacheInvalidationPublisher cacheInvalidationPublisher
     ) {
+        this.appealRepository = appealRepository;
         this.punishmentRepository = punishmentRepository;
         this.profileRepository = profileRepository;
         this.cacheInvalidationPublisher = cacheInvalidationPublisher;
+    }
+
+    /**
+     * Decides an eligible appeal end to end: looks it up, applies the status guard,
+     * decision-validity check, self-review rejection, SEVERE-tier full-lift ban, and
+     * duration-reduction expiry validation, then - if everything passes - applies the decision
+     * and persists the decided appeal. The single entry point {@code AppealController.review}
+     * calls, so the controller never branches on business rules itself.
+     */
+    public AppealReviewResult reviewAppeal(UUID appealIdentifier, AppealReviewDTO review) {
+        AppealEntity appeal = this.appealRepository.findById(appealIdentifier).orElse(null);
+        if (appeal == null) {
+            return AppealReviewResult.notFound();
+        }
+        if (appeal.getStatus() != AppealStatus.ELIGIBLE_PENDING_REVIEW && appeal.getStatus() != AppealStatus.IN_REVIEW) {
+            return AppealReviewResult.notAwaitingReview();
+        }
+        if (!VALID_DECISIONS.contains(review.decision())) {
+            return AppealReviewResult.invalidDecision("decision must be one of " + VALID_DECISIONS);
+        }
+
+        PunishmentEntity punishment = appeal.getPunishment();
+        if (review.reviewerId().equals(punishment.getSource())) {
+            return AppealReviewResult.selfReview();
+        }
+
+        boolean severe = "SEVERE".equals(appeal.getEligibilityCheckResult().get("severityTier"));
+        if (severe && review.decision() == AppealStatus.GRANTED_FULL_LIFT) {
+            return AppealReviewResult.severeFullLiftDisallowed();
+        }
+        if (review.decision() == AppealStatus.GRANTED_DURATION_REDUCTION) {
+            if (review.newExpirationAt() == null) {
+                return AppealReviewResult.durationReductionMissingExpiry();
+            }
+            if (review.newExpirationAt() <= System.currentTimeMillis()) {
+                return AppealReviewResult.durationReductionExpiryNotFuture();
+            }
+        }
+
+        DecisionOutcome outcome = applyDecision(
+                punishment, appeal.getAppellantHash(), review.decision(), review.newExpirationAt(), review.reviewerId()
+        );
+        if (outcome == DecisionOutcome.PUNISHMENT_NOT_ACTIVE) {
+            return AppealReviewResult.punishmentNotActive();
+        }
+
+        appeal.setStatus(review.decision());
+        appeal.setDecidedBy(review.reviewerId());
+        appeal.setDecisionNote(review.decisionNote());
+        appeal.setUpdatedAt(System.currentTimeMillis());
+        AppealEntity saved = this.appealRepository.update(appeal);
+
+        return AppealReviewResult.decided(saved);
     }
 
     /**
@@ -38,10 +115,15 @@ public class AppealDecisionService {
      * @param owner           the appellant's hashed owner (also the punishment's owner)
      * @param decision        {@code GRANTED_FULL_LIFT}, {@code GRANTED_DURATION_REDUCTION}, or {@code DENIED}
      * @param newExpirationAt required for {@code GRANTED_DURATION_REDUCTION}, ignored otherwise
+     * @param revokedBy       the reviewer granting the decision; stamped onto the punishment's own
+     *                        metadata for {@code GRANTED_FULL_LIFT}, matching
+     *                        {@code PunishmentApplicationService.revoke()}'s audit-trail pattern
      * @return whether the decision was applied, or {@code PUNISHMENT_NOT_ACTIVE} if the
      * punishment already expired/was lifted naturally in the meantime - nothing left to grant
      */
-    public DecisionOutcome applyDecision(PunishmentEntity punishment, String owner, AppealStatus decision, Long newExpirationAt) {
+    public DecisionOutcome applyDecision(
+            PunishmentEntity punishment, String owner, AppealStatus decision, Long newExpirationAt, UUID revokedBy
+    ) {
         if (decision == AppealStatus.DENIED) {
             return DecisionOutcome.APPLIED;
         }
@@ -59,11 +141,15 @@ public class AppealDecisionService {
         }
 
         if (decision == AppealStatus.GRANTED_FULL_LIFT) {
+            PunishmentEntity active = isActiveBan ? profile.getActiveBan() : profile.getActiveChatBan();
+            active.getMetaData().put("revokedBy", revokedBy.toString());
+            active.getMetaData().put(Metadata.META_DATA_KEY_UPDATE_DATE, System.currentTimeMillis());
+            this.punishmentRepository.update(active);
+
+            profile.getHistory().add(active);
             if (isActiveBan) {
-                profile.getHistory().add(profile.getActiveBan());
                 profile.setActiveBan(null);
             } else {
-                profile.getHistory().add(profile.getActiveChatBan());
                 profile.setActiveChatBan(null);
             }
             this.profileRepository.update(profile);

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/appeal/service/AppealEligibilityService.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/appeal/service/AppealEligibilityService.java
@@ -11,6 +11,7 @@ import net.onelitefeather.blackhole.backend.elo.EloProfileRepository;
 import net.onelitefeather.blackhole.backend.elo.service.EloService;
 import net.onelitefeather.blackhole.backend.elo.EloTrack;
 import net.onelitefeather.blackhole.backend.punishment.PunishmentEntity;
+import net.onelitefeather.blackhole.backend.punishment.PunishmentRepository;
 import net.onelitefeather.blackhole.backend.punishment.PunishType;
 import net.onelitefeather.phoca.metadata.Expirable;
 import net.onelitefeather.phoca.metadata.Metadata;
@@ -19,6 +20,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A fixed, versioned, configuration-driven checklist - not free text per appeal - that
@@ -33,6 +35,7 @@ public class AppealEligibilityService {
     public static final int CHECKLIST_VERSION = 1;
 
     private final AppealRepository appealRepository;
+    private final PunishmentRepository punishmentRepository;
     private final EloProfileRepository eloProfileRepository;
     private final int minDaysManual;
     private final int minDaysAuto;
@@ -41,6 +44,7 @@ public class AppealEligibilityService {
 
     public AppealEligibilityService(
             AppealRepository appealRepository,
+            PunishmentRepository punishmentRepository,
             EloProfileRepository eloProfileRepository,
             @Value("${blackhole.appeal.min-days-manual:14}") int minDaysManual,
             @Value("${blackhole.appeal.min-days-auto:3}") int minDaysAuto,
@@ -48,11 +52,37 @@ public class AppealEligibilityService {
             @Value("${blackhole.elo.baseline:1000}") int eloBaseline
     ) {
         this.appealRepository = appealRepository;
+        this.punishmentRepository = punishmentRepository;
         this.eloProfileRepository = eloProfileRepository;
         this.minDaysManual = minDaysManual;
         this.minDaysAuto = minDaysAuto;
         this.repeatAppealCooldownDays = repeatAppealCooldownDays;
         this.eloBaseline = eloBaseline;
+    }
+
+    /**
+     * Looks up the punishment being appealed, evaluates it against the eligibility checklist,
+     * and records the resulting appeal - the full submission flow so {@code AppealController}
+     * never has to touch {@link PunishmentRepository}/{@link AppealRepository} directly.
+     *
+     * @return the saved appeal, or empty if {@code punishmentIdentifier} doesn't match any
+     * existing punishment (submission is rejected, nothing is recorded)
+     */
+    public Optional<AppealEntity> submitAppeal(String punishmentIdentifier, String appellantHash, String statement) {
+        PunishmentEntity punishment = this.punishmentRepository.findById(punishmentIdentifier).orElse(null);
+        if (punishment == null) {
+            return Optional.empty();
+        }
+
+        EligibilityResult eligibility = evaluate(punishment, appellantHash);
+        long now = System.currentTimeMillis();
+
+        AppealEntity appeal = new AppealEntity(
+                punishment, appellantHash, statement,
+                eligibility.eligible() ? AppealStatus.ELIGIBLE_PENDING_REVIEW : AppealStatus.INELIGIBLE,
+                eligibility.checklistSnapshot(), now, now, new HashMap<>()
+        );
+        return Optional.of(this.appealRepository.save(appeal));
     }
 
     public EligibilityResult evaluate(PunishmentEntity punishment, String appellantHash) {

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/appeal/service/AppealEligibilityService.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/appeal/service/AppealEligibilityService.java
@@ -5,6 +5,8 @@ import net.onelitefeather.blackhole.backend.appeal.AppealRepository;
 import net.onelitefeather.blackhole.backend.appeal.AppealStatus;
 import net.onelitefeather.blackhole.backend.appeal.EligibilityResult;
 import io.micronaut.context.annotation.Value;
+import io.micronaut.data.model.Page;
+import io.micronaut.data.model.Pageable;
 import jakarta.inject.Singleton;
 import net.onelitefeather.blackhole.backend.elo.EloProfileEntity;
 import net.onelitefeather.blackhole.backend.elo.EloProfileRepository;
@@ -83,6 +85,14 @@ public class AppealEligibilityService {
                 eligibility.checklistSnapshot(), now, now, new HashMap<>()
         );
         return Optional.of(this.appealRepository.save(appeal));
+    }
+
+    /**
+     * Plain, read-only pass-through so {@code AppealController} never has to inject
+     * {@link AppealRepository} itself just to list appeals.
+     */
+    public Page<AppealEntity> findAll(Pageable pageable) {
+        return this.appealRepository.findAll(pageable);
     }
 
     public EligibilityResult evaluate(PunishmentEntity punishment, String appellantHash) {


### PR DESCRIPTION
## Summary
- `AppealController` inlined most of its review-decision logic (status guard, decision validity, self-review check, SEVERE-tier full-lift restriction, expiry validation) and injected `AppealRepository`/`PunishmentRepository` directly — the layering gap documented in `specs/003-appeal-workflow/plan.md`'s Constitution Check (Principle III, FAIL). Controller is now a thin adapter for both `submit()` and `review()`; `getAll()` no longer touches `AppealRepository` directly either (closed in a follow-up commit for consistency with the ELO fix in this same batch).
- Stamps `revokedBy`/update-date on the punishment when an appeal fully lifts it, matching `PunishmentApplicationService.revoke()`'s pattern — previously an appeal-caused lift was invisible in the punishment's own metadata history.
- Documents the `applyDecision`/appeal-update non-atomicity race in a class Javadoc, matching `EloService`'s existing documented-limitation style.
- No API/response-shape change.

## Test plan
- [x] `./gradlew :backend:compileJava` succeeds
- [x] Verified against real Docker infra: appeal submission, getAll, review-not-found(404), review-not-awaiting-review(409) all behave identically to pre-refactor