### PR TITLE
refactor(backend): extract ReportService from ReportController

### DIFF
--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/report/controller/ReportController.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/report/controller/ReportController.java
@@ -1,12 +1,9 @@
 package net.onelitefeather.blackhole.backend.report.controller;
 
-import net.onelitefeather.blackhole.backend.report.ReportEntity;
-import net.onelitefeather.blackhole.backend.report.ReportRepository;
-import net.onelitefeather.blackhole.backend.report.ReportStatus;
 import net.onelitefeather.blackhole.backend.report.dto.ReportDTO;
 import net.onelitefeather.blackhole.backend.report.dto.ReportRequestDTO;
 import net.onelitefeather.blackhole.backend.report.dto.ReportResolutionDTO;
-import io.micronaut.context.annotation.Value;
+import net.onelitefeather.blackhole.backend.report.service.ReportService;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.http.HttpResponse;
@@ -25,29 +22,21 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import net.onelitefeather.blackhole.backend.controller.ApiVersion;
-import net.onelitefeather.blackhole.backend.elo.EloReasonCode;
-import net.onelitefeather.blackhole.backend.elo.service.EloService;
-import net.onelitefeather.blackhole.backend.elo.EloTrack;
-import net.onelitefeather.blackhole.backend.events.DomainEventPublisher;
-import net.onelitefeather.blackhole.backend.punishment.service.PunishmentApplicationService;
 
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 
 /**
  * Player reports. Submission is rate-limited per {@code reporterHash} - otherwise reporting
  * itself becomes a griefing vector. Resolution can optionally apply a punishment template to the
- * reported player through {@link PunishmentApplicationService}, the report system's actual
- * integration point with punishments rather than a parallel/separate mechanism.
+ * reported player, the report system's actual integration point with punishments rather than a
+ * parallel/separate mechanism. All of that logic lives in {@link ReportService}; this controller
+ * only parses/validates the request, delegates, and maps the result to an {@code HttpResponse}.
  *
  * <p><b>Security note:</b> {@code reporterHash} is client-supplied - there is no authentication in
  * this system at all, so nothing here can verify it actually belongs to the caller. A
  * per-reporterHash limit alone is therefore bypassable by simply varying that field on every
- * request; {@link #rateLimitMaxReportsNetworkWide} is an aggregate, network-wide backstop that
- * caps the blast radius regardless of what {@code reporterHash} value is claimed.</p>
+ * request; the service's network-wide rate limit is an aggregate backstop that caps the blast
+ * radius regardless of what {@code reporterHash} value is claimed.</p>
  *
  * <p><b>Known limitation (deferred, not fixed here):</b> {@code resolve}'s {@code resolvedBy}
  * and {@code punishmentSource} are likewise client-supplied and unverified against the caller's
@@ -61,37 +50,11 @@ import java.util.UUID;
 @Controller("/report")
 public class ReportController {
 
-    private final ReportRepository reportRepository;
-    private final DomainEventPublisher eventPublisher;
-    private final PunishmentApplicationService punishmentApplicationService;
-    private final EloService eloService;
-    private final int rateLimitMaxReports;
-    private final int rateLimitMaxReportsNetworkWide;
-    private final Duration rateLimitWindow;
-    private final int reportActionedDelta;
-    private final int reportRewardDelta;
+    private final ReportService reportService;
 
     @Inject
-    public ReportController(
-            ReportRepository reportRepository,
-            DomainEventPublisher eventPublisher,
-            PunishmentApplicationService punishmentApplicationService,
-            EloService eloService,
-            @Value("${blackhole.report.rate-limit.max-reports:5}") int rateLimitMaxReports,
-            @Value("${blackhole.report.rate-limit.max-reports-network-wide:50}") int rateLimitMaxReportsNetworkWide,
-            @Value("${blackhole.report.rate-limit.window:PT10M}") Duration rateLimitWindow,
-            @Value("${blackhole.elo.report.actioned-delta:-100}") int reportActionedDelta,
-            @Value("${blackhole.elo.report.reward-delta:50}") int reportRewardDelta
-    ) {
-        this.reportRepository = reportRepository;
-        this.eventPublisher = eventPublisher;
-        this.punishmentApplicationService = punishmentApplicationService;
-        this.eloService = eloService;
-        this.rateLimitMaxReports = rateLimitMaxReports;
-        this.rateLimitMaxReportsNetworkWide = rateLimitMaxReportsNetworkWide;
-        this.rateLimitWindow = rateLimitWindow;
-        this.reportActionedDelta = reportActionedDelta;
-        this.reportRewardDelta = reportRewardDelta;
+    public ReportController(ReportService reportService) {
+        this.reportService = reportService;
     }
 
     @Operation(
@@ -109,44 +72,11 @@ public class ReportController {
     @Validated
     @Post("/")
     public HttpResponse<?> submit(@Body @Valid ReportRequestDTO submission) {
-        long now = System.currentTimeMillis();
-        long windowStart = now - this.rateLimitWindow.toMillis();
-
-        long recentNetworkReports = this.reportRepository.countByCreatedAtGreaterThan(windowStart);
-        if (recentNetworkReports >= this.rateLimitMaxReportsNetworkWide) {
-            return HttpResponse.status(HttpStatus.TOO_MANY_REQUESTS);
-        }
-
-        long recentReports = this.reportRepository.countByReporterHashAndCreatedAtGreaterThan(
-                submission.reporterHash(), windowStart
-        );
-        if (recentReports >= this.rateLimitMaxReports) {
-            return HttpResponse.status(HttpStatus.TOO_MANY_REQUESTS);
-        }
-
-        ReportEntity report = new ReportEntity(
-                submission.reporterHash(),
-                submission.reportedHash(),
-                submission.category(),
-                submission.description(),
-                submission.evidenceReferences() == null ? new ArrayList<>() : submission.evidenceReferences(),
-                ReportStatus.OPEN,
-                now,
-                now,
-                null,
-                null,
-                submission.metaData() == null ? new HashMap<>() : submission.metaData()
-        );
-        ReportEntity saved = this.reportRepository.save(report);
-
-        this.eventPublisher.publish("report.created", Map.of(
-                "reportIdentifier", saved.getIdentifier().toString(),
-                "reporterHash", submission.reporterHash(),
-                "reportedHash", submission.reportedHash(),
-                "category", submission.category().toString()
-        ));
-
-        return HttpResponse.ok(saved.toDTO());
+        ReportService.SubmitResult result = this.reportService.submit(submission);
+        return switch (result) {
+            case ReportService.SubmitResult.Success success -> HttpResponse.ok(success.report());
+            case ReportService.SubmitResult.RateLimited ignored -> HttpResponse.status(HttpStatus.TOO_MANY_REQUESTS);
+        };
     }
 
     @Operation(
@@ -165,8 +95,7 @@ public class ReportController {
     )
     @Get("/")
     public HttpResponse<Page<ReportDTO>> getAll(Pageable pageable) {
-        Page<ReportEntity> entities = this.reportRepository.findAll(pageable);
-        return HttpResponse.ok(entities.map(ReportEntity::toDTO));
+        return HttpResponse.ok(this.reportService.getAll(pageable));
     }
 
     @Operation(
@@ -185,61 +114,12 @@ public class ReportController {
     @Validated
     @Post("/{identifier}/resolve")
     public HttpResponse<?> resolve(UUID identifier, @Body @Valid ReportResolutionDTO resolution) {
-        ReportEntity report = this.reportRepository.findById(identifier).orElse(null);
-        if (report == null) {
-            return HttpResponse.notFound();
-        }
-
-        if (resolution.punishmentTemplateId() != null) {
-            if (resolution.punishmentSource() == null) {
-                return HttpResponse.badRequest("punishmentSource is required when punishmentTemplateId is set");
-            }
-            var applied = this.punishmentApplicationService.apply(
-                    report.getReportedHash(), resolution.punishmentTemplateId(), resolution.punishmentSource()
-            );
-            if (applied.isEmpty()) {
-                return HttpResponse.notFound();
-            }
-        }
-
-        report.setStatus(resolution.status());
-        report.setResolutionNote(resolution.resolutionNote());
-        report.setResolvedBy(resolution.resolvedBy());
-        report.setUpdatedAt(System.currentTimeMillis());
-        ReportEntity saved = this.reportRepository.update(report);
-
-        if (resolution.status() == ReportStatus.ACTIONED) {
-            EloTrack track = switch (report.getCategory()) {
-                case CHAT_ABUSE -> EloTrack.CHAT;
-                case CHEATING, GRIEFING -> EloTrack.GAMEPLAY;
-                case OTHER -> null;
-            };
-            if (track != null) {
-                this.eloService.applyDelta(
-                        report.getReportedHash(), track, this.reportActionedDelta, EloReasonCode.REPORT_ACTIONED, null,
-                        Map.of("reportIdentifier", identifier.toString(), "category", report.getCategory().toString())
-                );
-
-                // resolution.punishmentTemplateId() != null implies a punishment was actually
-                // applied above (an empty apply() result returns 404 before this point is
-                // reached) - a report only earns its reporter Elo when it demonstrably banned
-                // someone, not merely when a staff member marked it ACTIONED without acting.
-                if (resolution.punishmentTemplateId() != null) {
-                    this.eloService.applyDelta(
-                            report.getReporterHash(), track, this.reportRewardDelta, EloReasonCode.REPORT_REWARDED, null,
-                            Map.of("reportIdentifier", identifier.toString(), "category", report.getCategory().toString())
-                    );
-                }
-            }
-        }
-
-        this.eventPublisher.publish("report.resolved", Map.of(
-                "reportIdentifier", identifier.toString(),
-                "reportedHash", report.getReportedHash(),
-                "status", resolution.status().toString(),
-                "resolvedBy", resolution.resolvedBy().toString()
-        ));
-
-        return HttpResponse.ok(saved.toDTO());
+        ReportService.ResolveResult result = this.reportService.resolve(identifier, resolution);
+        return switch (result) {
+            case ReportService.ResolveResult.Success success -> HttpResponse.ok(success.report());
+            case ReportService.ResolveResult.NotFound ignored -> HttpResponse.notFound();
+            case ReportService.ResolveResult.PunishmentSourceRequired ignored ->
+                    HttpResponse.badRequest("punishmentSource is required when punishmentTemplateId is set");
+        };
     }
 }

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/report/service/ReportService.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/report/service/ReportService.java
@@ -1,0 +1,223 @@
+package net.onelitefeather.blackhole.backend.report.service;
+
+import net.onelitefeather.blackhole.backend.report.ReportEntity;
+import net.onelitefeather.blackhole.backend.report.ReportRepository;
+import net.onelitefeather.blackhole.backend.report.ReportStatus;
+import net.onelitefeather.blackhole.backend.report.dto.ReportDTO;
+import net.onelitefeather.blackhole.backend.report.dto.ReportRequestDTO;
+import net.onelitefeather.blackhole.backend.report.dto.ReportResolutionDTO;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.data.model.Page;
+import io.micronaut.data.model.Pageable;
+import jakarta.inject.Singleton;
+import net.onelitefeather.blackhole.backend.elo.EloReasonCode;
+import net.onelitefeather.blackhole.backend.elo.EloTrack;
+import net.onelitefeather.blackhole.backend.elo.service.EloService;
+import net.onelitefeather.blackhole.backend.events.DomainEventPublisher;
+import net.onelitefeather.blackhole.backend.punishment.service.PunishmentApplicationService;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Owns the report lifecycle: rate-limited submission, and resolution (optionally applying a
+ * punishment template to the reported player through {@link PunishmentApplicationService} and
+ * feeding both ELO tracks' standing effects through {@link EloService}). Extracted from
+ * {@code ReportController}, which previously inlined all of this directly - the most severe
+ * layering gap found across the retroactive spec-kit review of the 6 subsystems (see
+ * {@code specs/006-player-reports/plan.md}'s Constitution Check).
+ *
+ * <p><b>Ordering matters for {@link #resolve}:</b> punishment-template lookup/application is
+ * attempted first, and any failure there (template missing) is returned before a single field on
+ * the {@link ReportEntity} is mutated - so a failed resolution never leaves the report
+ * half-updated (FR-013/SC-006's "no partial completion" guarantee). Preserve this ordering in any
+ * future change to this method.</p>
+ *
+ * <p><b>Security note:</b> {@code reporterHash} is client-supplied - there is no authentication in
+ * this system at all, so nothing here can verify it actually belongs to the caller. A
+ * per-reporterHash limit alone is therefore bypassable by simply varying that field on every
+ * request; {@code rateLimitMaxReportsNetworkWide} is an aggregate, network-wide backstop that caps
+ * the blast radius regardless of what {@code reporterHash} value is claimed.</p>
+ *
+ * <p><b>Known limitation (deferred, not fixed here):</b> {@code resolve}'s {@code resolvedBy} and
+ * {@code punishmentSource} are likewise client-supplied and unverified against the caller's actual
+ * identity - the same property {@code PunishmentEntityController}'s {@code source} field has had
+ * since Phase 0. This is a systemic actor-identity gap, not something specific to reports, and is
+ * intentionally deferred to a dedicated pass that adds real per-actor identity (and, if
+ * reintroduced, authentication) everywhere at once rather than patching one endpoint
+ * inconsistently with the rest.</p>
+ *
+ * <p><b>Known limitation (deferred, not fixed here):</b> {@code resolve} accepts any status and
+ * can be re-invoked on the same report, re-triggering its standing ELO effects each time - there
+ * is no status state machine enforcing valid transitions. Preserved as-is; introducing one is a
+ * separate, more invasive behavioral change.</p>
+ */
+@Singleton
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final DomainEventPublisher eventPublisher;
+    private final PunishmentApplicationService punishmentApplicationService;
+    private final EloService eloService;
+    private final int rateLimitMaxReports;
+    private final int rateLimitMaxReportsNetworkWide;
+    private final Duration rateLimitWindow;
+    private final int reportActionedDelta;
+    private final int reportRewardDelta;
+
+    public ReportService(
+            ReportRepository reportRepository,
+            DomainEventPublisher eventPublisher,
+            PunishmentApplicationService punishmentApplicationService,
+            EloService eloService,
+            @Value("${blackhole.report.rate-limit.max-reports:5}") int rateLimitMaxReports,
+            @Value("${blackhole.report.rate-limit.max-reports-network-wide:50}") int rateLimitMaxReportsNetworkWide,
+            @Value("${blackhole.report.rate-limit.window:PT10M}") Duration rateLimitWindow,
+            @Value("${blackhole.elo.report.actioned-delta:-100}") int reportActionedDelta,
+            @Value("${blackhole.elo.report.reward-delta:50}") int reportRewardDelta
+    ) {
+        this.reportRepository = reportRepository;
+        this.eventPublisher = eventPublisher;
+        this.punishmentApplicationService = punishmentApplicationService;
+        this.eloService = eloService;
+        this.rateLimitMaxReports = rateLimitMaxReports;
+        this.rateLimitMaxReportsNetworkWide = rateLimitMaxReportsNetworkWide;
+        this.rateLimitWindow = rateLimitWindow;
+        this.reportActionedDelta = reportActionedDelta;
+        this.reportRewardDelta = reportRewardDelta;
+    }
+
+    /**
+     * Outcome of {@link #submit}. An expected failure (rate limit) is a variant here rather than
+     * an exception, so the controller maps it to an {@code HttpResponse} without try/catch.
+     */
+    public sealed interface SubmitResult {
+        record Success(ReportDTO report) implements SubmitResult {
+        }
+
+        record RateLimited() implements SubmitResult {
+        }
+    }
+
+    /**
+     * Outcome of {@link #resolve}. Expected failures are variants here rather than exceptions, so
+     * the controller maps them to an {@code HttpResponse} without try/catch.
+     */
+    public sealed interface ResolveResult {
+        record Success(ReportDTO report) implements ResolveResult {
+        }
+
+        record NotFound() implements ResolveResult {
+        }
+
+        record PunishmentSourceRequired() implements ResolveResult {
+        }
+    }
+
+    public Page<ReportDTO> getAll(Pageable pageable) {
+        return this.reportRepository.findAll(pageable).map(ReportEntity::toDTO);
+    }
+
+    public SubmitResult submit(ReportRequestDTO submission) {
+        long now = System.currentTimeMillis();
+        long windowStart = now - this.rateLimitWindow.toMillis();
+
+        long recentNetworkReports = this.reportRepository.countByCreatedAtGreaterThan(windowStart);
+        if (recentNetworkReports >= this.rateLimitMaxReportsNetworkWide) {
+            return new SubmitResult.RateLimited();
+        }
+
+        long recentReports = this.reportRepository.countByReporterHashAndCreatedAtGreaterThan(
+                submission.reporterHash(), windowStart
+        );
+        if (recentReports >= this.rateLimitMaxReports) {
+            return new SubmitResult.RateLimited();
+        }
+
+        ReportEntity report = new ReportEntity(
+                submission.reporterHash(),
+                submission.reportedHash(),
+                submission.category(),
+                submission.description(),
+                submission.evidenceReferences() == null ? new ArrayList<>() : submission.evidenceReferences(),
+                ReportStatus.OPEN,
+                now,
+                now,
+                null,
+                null,
+                submission.metaData() == null ? new HashMap<>() : submission.metaData()
+        );
+        ReportEntity saved = this.reportRepository.save(report);
+
+        this.eventPublisher.publish("report.created", Map.of(
+                "reportIdentifier", saved.getIdentifier().toString(),
+                "reporterHash", submission.reporterHash(),
+                "reportedHash", submission.reportedHash(),
+                "category", submission.category().toString()
+        ));
+
+        return new SubmitResult.Success(saved.toDTO());
+    }
+
+    public ResolveResult resolve(UUID identifier, ReportResolutionDTO resolution) {
+        ReportEntity report = this.reportRepository.findById(identifier).orElse(null);
+        if (report == null) {
+            return new ResolveResult.NotFound();
+        }
+
+        if (resolution.punishmentTemplateId() != null) {
+            if (resolution.punishmentSource() == null) {
+                return new ResolveResult.PunishmentSourceRequired();
+            }
+            var applied = this.punishmentApplicationService.apply(
+                    report.getReportedHash(), resolution.punishmentTemplateId(), resolution.punishmentSource()
+            );
+            if (applied.isEmpty()) {
+                return new ResolveResult.NotFound();
+            }
+        }
+
+        report.setStatus(resolution.status());
+        report.setResolutionNote(resolution.resolutionNote());
+        report.setResolvedBy(resolution.resolvedBy());
+        report.setUpdatedAt(System.currentTimeMillis());
+        ReportEntity saved = this.reportRepository.update(report);
+
+        if (resolution.status() == ReportStatus.ACTIONED) {
+            EloTrack track = switch (report.getCategory()) {
+                case CHAT_ABUSE -> EloTrack.CHAT;
+                case CHEATING, GRIEFING -> EloTrack.GAMEPLAY;
+                case OTHER -> null;
+            };
+            if (track != null) {
+                this.eloService.applyDelta(
+                        report.getReportedHash(), track, this.reportActionedDelta, EloReasonCode.REPORT_ACTIONED, null,
+                        Map.of("reportIdentifier", identifier.toString(), "category", report.getCategory().toString())
+                );
+
+                // resolution.punishmentTemplateId() != null implies a punishment was actually
+                // applied above (an empty apply() result returns NotFound before this point is
+                // reached) - a report only earns its reporter Elo when it demonstrably banned
+                // someone, not merely when a staff member marked it ACTIONED without acting.
+                if (resolution.punishmentTemplateId() != null) {
+                    this.eloService.applyDelta(
+                            report.getReporterHash(), track, this.reportRewardDelta, EloReasonCode.REPORT_REWARDED, null,
+                            Map.of("reportIdentifier", identifier.toString(), "category", report.getCategory().toString())
+                    );
+                }
+            }
+        }
+
+        this.eventPublisher.publish("report.resolved", Map.of(
+                "reportIdentifier", identifier.toString(),
+                "reportedHash", report.getReportedHash(),
+                "status", resolution.status().toString(),
+                "resolvedBy", resolution.resolvedBy().toString()
+        ));
+
+        return new ResolveResult.Success(saved.toDTO());
+    }
+}


### PR DESCRIPTION
## Summary
- `ReportController` had no service layer at all — rate limiting, punishment application, both ELO deltas (`REPORT_ACTIONED`/`REPORT_REWARDED`), and event publishing were all inline in `resolve()`, injecting `ReportRepository` directly. The most severe layering gap found across all 6 retroactive specs, documented in `specs/006-player-reports/plan.md`'s Constitution Check (Principle III, FAIL).
- Extracts `ReportService` (sealed `SubmitResult`/`ResolveResult` outcome types); controller is now a thin adapter.
- Preserves the exact fail-fast-before-mutation ordering (a missing punishment template rejects before any `ReportEntity` field is touched) and the ELO-effect gating (`REPORT_ACTIONED` fires on any actioned resolution mapping to a track; `REPORT_REWARDED` only when a punishment was actually applied).
- No API/response-shape or behavioral change.

## Test plan
- [x] `./gradlew :backend:compileJava` succeeds
- [x] Verified against real Docker infra: submit, getAll, resolve-without-punishment (reported player's ELO hit fires, reporter gets nothing), resolve-with-bad-template (404, report untouched), resolve-missing-punishmentSource (400), full happy path with a real punishment applied (both reported-player penalty and reporter reward fire on the correct tracks) — all identical to pre-refactor behavior