### PR TITLE
docs: fix stale "no tests exist anywhere" claim in CLAUDE.md and specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,10 @@ cd docker && docker compose up -d && cd ..
 ./gradlew :velocity:runVelocity
 ```
 
-There are currently no test source sets under any module (`src/test` doesn't exist yet) — when
-adding tests, JUnit 5 is already wired up via the Micronaut/root `build.gradle.kts` (`useJUnitPlatform()`,
-`jacocoTestReport` runs after `test`). Local dev/manual verification of the backend requires the
+Test coverage is minimal — only `backend/src/test/java/.../playerresolver/service/PlayerResolverServiceTest.java`
+exists so far, no other module has a `src/test` yet. JUnit 5 is wired up via the Micronaut/root
+`build.gradle.kts` (`useJUnitPlatform()`, `jacocoTestReport` runs after `test`), ready for more.
+Local dev/manual verification of the backend requires the
 real MariaDB + RabbitMQ containers from `docker/docker-compose.yml`; there's no in-memory/mocked
 path for those two dependencies (H2 is on the classpath but the app is wired to Liquibase+MariaDB
 by default — see `application.yml`).

--- a/specs/001-elo-engine/plan.md
+++ b/specs/001-elo-engine/plan.md
@@ -46,10 +46,12 @@ player, both track scores) and `elo_events` (append-only audit trail, indexed on
 custom `MapStringObjectConverter`.
 
 **Testing**: JUnit 5 is wired at the root (`useJUnitPlatform()`,
-`jacocoTestReport` runs after `test`), but **no test sources currently exist** for this
-feature (or any feature — no `backend/src/test` directory exists yet in this repo). This
-is a real gap, not a design choice; recorded here rather than silently assumed away so
-`/speckit-tasks` can decide whether to close it.
+`jacocoTestReport` runs after `test`), but **no test sources currently exist for this
+feature** — the only test in the repo so far is
+`backend/src/test/java/.../playerresolver/service/PlayerResolverServiceTest.java`,
+an unrelated subsystem. This is a real gap for this feature, not a design choice;
+recorded here rather than silently assumed away so `/speckit-tasks` can decide whether
+to close it.
 
 **Target Platform**: Linux server, single Micronaut HTTP API deployment per network
 (this repo's `backend` module); no offline/embedded execution mode.
@@ -146,7 +148,7 @@ backend/src/main/resources/
 ├── application.yml               # blackhole.elo.* tunables
 └── db/changelog/                 # Liquibase changesets for elo_profiles / elo_events
 
-backend/src/test/                 # does not exist yet — see Technical Context "Testing"
+backend/src/test/                 # no elo/ tests yet — see Technical Context "Testing"
 ```
 
 **Structure Decision**: No new module or service boundary — the ELO engine is fully

--- a/specs/002-punishment-core/plan.md
+++ b/specs/002-punishment-core/plan.md
@@ -71,9 +71,11 @@ Principle VI) being followed correctly. `meta_data` columns use a JSON column ty
 `MapStringObjectConverter`, same pattern as the ELO engine.
 
 **Testing**: JUnit 5 is wired at the root (`useJUnitPlatform()`, `jacocoTestReport`
-runs after `test`), but **no test sources exist** for this feature or any other feature
-in the repo (`backend/src/test` does not exist). Recorded here rather than silently
-assumed away, matching `specs/001-elo-engine/plan.md`'s note on the same gap.
+runs after `test`), but **no test sources exist for this feature** — the only test in
+the repo so far is
+`backend/src/test/java/.../playerresolver/service/PlayerResolverServiceTest.java`, an
+unrelated subsystem. Recorded here rather than silently assumed away, matching
+`specs/001-elo-engine/plan.md`'s note on the same gap.
 
 **Target Platform**: Linux server, single Micronaut HTTP API deployment per network
 (this repo's `backend` module); the Redis mirror and Rabbit consumer run in-process
@@ -193,7 +195,7 @@ backend/src/main/resources/
                                      # punishment_profiles/punishment_profiles_punishments/
                                      # punishment_evidence
 
-backend/src/test/                   # does not exist yet — see Technical Context "Testing"
+backend/src/test/                   # no punishment/ tests yet — see Technical Context "Testing"
 ```
 
 **Structure Decision**: No new module or service boundary — the punishment core is

--- a/specs/003-appeal-workflow/plan.md
+++ b/specs/003-appeal-workflow/plan.md
@@ -56,9 +56,10 @@ same `MapStringObjectConverter` pattern used elsewhere in the backend; `status` 
 no `CHECK`-expression changeType — see `.claude/rules/database.md`).
 
 **Testing**: JUnit 5 is wired at the root (`useJUnitPlatform()`), but **no test sources
-exist** for this feature, or any feature — no `backend/src/test` directory exists yet in
-this repo. Same gap already recorded in `specs/001-elo-engine/plan.md`; not re-litigated
-here.
+exist for this feature** — the only test in the repo so far is
+`backend/src/test/java/.../playerresolver/service/PlayerResolverServiceTest.java`, an
+unrelated subsystem. Same gap already recorded in `specs/001-elo-engine/plan.md`; not
+re-litigated here.
 
 **Target Platform**: Linux server, single Micronaut HTTP API deployment per network
 (this repo's `backend` module); no offline/embedded execution mode.
@@ -148,7 +149,7 @@ backend/src/main/resources/
 ├── application.yml               # blackhole.appeal.* tunables
 └── db/changelog/                 # Liquibase changesets for the appeals table
 
-backend/src/test/                 # does not exist yet — see Technical Context "Testing"
+backend/src/test/                 # no appeal/ tests yet — see Technical Context "Testing"
 ```
 
 **Structure Decision**: No new module or service boundary — the appeal workflow is fully

--- a/specs/004-evasion-detection/plan.md
+++ b/specs/004-evasion-detection/plan.md
@@ -51,9 +51,11 @@ JSON column via the shared `MapStringObjectConverter`, present on the entity but
 populated by any current write path.
 
 **Testing**: JUnit 5 is wired at the root (`useJUnitPlatform()`, `jacocoTestReport` runs
-after `test`), but **no test sources currently exist** for this feature (or any feature —
-no `backend/src/test` directory exists yet in this repo). Recorded here rather than
-silently assumed away so `/speckit-tasks` can decide whether to close it.
+after `test`), but **no test sources currently exist for this feature** — the only test
+in the repo so far is
+`backend/src/test/java/.../playerresolver/service/PlayerResolverServiceTest.java`, an
+unrelated subsystem. Recorded here rather than silently assumed away so
+`/speckit-tasks` can decide whether to close it.
 
 **Target Platform**: Linux server, single Micronaut HTTP API deployment per network
 (this repo's `backend` module); no offline/embedded execution mode. The only caller today
@@ -147,7 +149,7 @@ backend/src/main/resources/
 velocity/src/main/java/net/onelitefeather/blackhole/velocity/listener/
 └── PlayerLoginListener.java             # only current caller — recordEvasionSignal(), fire-and-forget on login
 
-backend/src/test/                        # does not exist yet — see Technical Context "Testing"
+backend/src/test/                        # no evasion/ tests yet — see Technical Context "Testing"
 ```
 
 **Structure Decision**: No new module or service boundary — ban-evasion detection is

--- a/specs/005-vanilla-import/plan.md
+++ b/specs/005-vanilla-import/plan.md
@@ -57,8 +57,9 @@ the `punishment`/`profile` features' own Liquibase changesets) that every other
 punishment-creation path writes to; this feature owns no schema of its own.
 
 **Testing**: JUnit 5 is wired at the root (`useJUnitPlatform()`), but **no test sources
-currently exist** for this feature (or any feature — no `backend/src/test` directory
-exists yet in this repo). Same gap as every other retroactively-planned feature in this
+currently exist for this feature** — the only test in the repo so far is
+`backend/src/test/java/.../playerresolver/service/PlayerResolverServiceTest.java`, an
+unrelated subsystem. Same gap as every other retroactively-planned feature in this
 repo; recorded here rather than silently assumed away.
 
 **Target Platform**: Linux server, single Micronaut HTTP API deployment per network
@@ -158,7 +159,7 @@ backend/src/main/java/net/onelitefeather/blackhole/backend/imports/
 backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/
 └── service/PunishmentApplicationService.java   # NOT called by this feature — see research.md
 
-backend/src/test/                 # does not exist yet — see Technical Context "Testing"
+backend/src/test/                 # no imports/ tests yet — see Technical Context "Testing"
 ```
 
 **Structure Decision**: No new module or service boundary — the import capability is

--- a/specs/006-player-reports/plan.md
+++ b/specs/006-player-reports/plan.md
@@ -56,8 +56,9 @@ blob. `metaData` uses the same `MapStringObjectConverter`/JSON-column pattern as
 feature packages.
 
 **Testing**: JUnit 5 is wired at the root (`useJUnitPlatform()`), but **no test sources
-exist** for this feature (or any feature — no `backend/src/test` directory exists yet in
-this repo). Recorded here rather than silently assumed away, consistent with
+exist for this feature** — the only test in the repo so far is
+`backend/src/test/java/.../playerresolver/service/PlayerResolverServiceTest.java`, an
+unrelated subsystem. Recorded here rather than silently assumed away, consistent with
 `specs/001-elo-engine/plan.md`.
 
 **Target Platform**: Linux server, single Micronaut HTTP API deployment per network
@@ -153,7 +154,7 @@ backend/src/main/resources/
 ├── application.yml               # blackhole.report.* tunables (rate limit) + blackhole.elo.report.* (actioned-delta, reward-delta)
 └── db/changelog/                 # Liquibase changeset(s) for reports / report_evidence_references
 
-backend/src/test/                 # does not exist yet — see Technical Context "Testing"
+backend/src/test/                 # no report/ tests yet — see Technical Context "Testing"
 ```
 
 **Structure Decision**: No new module or service boundary — reports are fully contained


### PR DESCRIPTION
## Summary
- `backend/src/test/java/.../playerresolver/service/PlayerResolverServiceTest.java` has existed since commit `b22357f`, but `CLAUDE.md` and all 6 retroactive `plan.md` files (from #119) claimed no test sources exist anywhere in the repo.
- Found during a multi-agent review of #119's content (already merged).
- Corrects the claim to "no tests for this feature specifically" (still true for all 6 subsystems) rather than "no tests at all" (false).

## Test plan
- Docs-only change, no code affected.