### PR TITLE
refactor(backend): extract ReportApi, document report resolve() non-atomicity

### DIFF
--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/report/controller/ReportApi.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/report/controller/ReportApi.java
@@ -1,0 +1,73 @@
+package net.onelitefeather.blackhole.backend.report.controller;
+
+import net.onelitefeather.blackhole.backend.report.dto.ReportDTO;
+import net.onelitefeather.blackhole.backend.report.dto.ReportRequestDTO;
+import net.onelitefeather.blackhole.backend.report.dto.ReportResolutionDTO;
+import io.micronaut.data.model.Page;
+import io.micronaut.data.model.Pageable;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.validation.Validated;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+
+import java.util.UUID;
+
+public interface ReportApi {
+
+    @Operation(
+            summary = "Submit a report",
+            description = "Submits a player report. Rate-limited per reporterHash within a configurable time window.",
+            operationId = "submitReport",
+            tags = {"Report"}
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Report successfully submitted",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReportDTO.class))
+    )
+    @ApiResponse(responseCode = "429", description = "Rate limit exceeded for this reporter")
+    @Validated
+    @Post("/")
+    HttpResponse<?> submit(@Body @Valid ReportRequestDTO submission);
+
+    @Operation(
+            summary = "Get all reports",
+            description = "Retrieves a paginated list of reports",
+            operationId = "getReports",
+            tags = {"Report"}
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Successfully retrieved reports",
+            content = @Content(
+                    mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = ReportDTO.class), arraySchema = @Schema(implementation = Page.class))
+            )
+    )
+    @Get("/")
+    HttpResponse<Page<ReportDTO>> getAll(Pageable pageable);
+
+    @Operation(
+            summary = "Resolve a report",
+            description = "Resolves a report, optionally applying a punishment template to the reported player",
+            operationId = "resolveReport",
+            tags = {"Report"}
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Report successfully resolved",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReportDTO.class))
+    )
+    @ApiResponse(responseCode = "404", description = "Report or punishment template not found")
+    @ApiResponse(responseCode = "400", description = "punishmentSource is required when punishmentTemplateId is set")
+    @Validated
+    @Post("/{identifier}/resolve")
+    HttpResponse<?> resolve(UUID identifier, @Body @Valid ReportResolutionDTO resolution);
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/report/controller/ReportController.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/report/controller/ReportController.java
@@ -1,6 +1,5 @@
 package net.onelitefeather.blackhole.backend.report.controller;
 
-import net.onelitefeather.blackhole.backend.report.dto.ReportDTO;
 import net.onelitefeather.blackhole.backend.report.dto.ReportRequestDTO;
 import net.onelitefeather.blackhole.backend.report.dto.ReportResolutionDTO;
 import net.onelitefeather.blackhole.backend.report.service.ReportService;
@@ -8,20 +7,11 @@ import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
-import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
-import io.micronaut.http.annotation.Get;
-import io.micronaut.http.annotation.Post;
 import io.micronaut.core.version.annotation.Version;
-import io.micronaut.validation.Validated;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.inject.Inject;
-import jakarta.validation.Valid;
 import net.onelitefeather.blackhole.backend.controller.ApiVersion;
+import net.onelitefeather.blackhole.backend.report.dto.ReportDTO;
 
 import java.util.UUID;
 
@@ -31,6 +21,7 @@ import java.util.UUID;
  * reported player, the report system's actual integration point with punishments rather than a
  * parallel/separate mechanism. All of that logic lives in {@link ReportService}; this controller
  * only parses/validates the request, delegates, and maps the result to an {@code HttpResponse}.
+ * Routing and OpenAPI annotations live on {@link ReportApi}, which this class implements.
  *
  * <p><b>Security note:</b> {@code reporterHash} is client-supplied - there is no authentication in
  * this system at all, so nothing here can verify it actually belongs to the caller. A
@@ -48,7 +39,7 @@ import java.util.UUID;
  */
 @Version(ApiVersion.V1)
 @Controller("/report")
-public class ReportController {
+public class ReportController implements ReportApi {
 
     private final ReportService reportService;
 
@@ -57,21 +48,8 @@ public class ReportController {
         this.reportService = reportService;
     }
 
-    @Operation(
-            summary = "Submit a report",
-            description = "Submits a player report. Rate-limited per reporterHash within a configurable time window.",
-            operationId = "submitReport",
-            tags = {"Report"}
-    )
-    @ApiResponse(
-            responseCode = "200",
-            description = "Report successfully submitted",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReportDTO.class))
-    )
-    @ApiResponse(responseCode = "429", description = "Rate limit exceeded for this reporter")
-    @Validated
-    @Post("/")
-    public HttpResponse<?> submit(@Body @Valid ReportRequestDTO submission) {
+    @Override
+    public HttpResponse<?> submit(ReportRequestDTO submission) {
         ReportService.SubmitResult result = this.reportService.submit(submission);
         return switch (result) {
             case ReportService.SubmitResult.Success success -> HttpResponse.ok(success.report());
@@ -79,41 +57,13 @@ public class ReportController {
         };
     }
 
-    @Operation(
-            summary = "Get all reports",
-            description = "Retrieves a paginated list of reports",
-            operationId = "getReports",
-            tags = {"Report"}
-    )
-    @ApiResponse(
-            responseCode = "200",
-            description = "Successfully retrieved reports",
-            content = @Content(
-                    mediaType = "application/json",
-                    array = @ArraySchema(schema = @Schema(implementation = ReportDTO.class), arraySchema = @Schema(implementation = Page.class))
-            )
-    )
-    @Get("/")
+    @Override
     public HttpResponse<Page<ReportDTO>> getAll(Pageable pageable) {
         return HttpResponse.ok(this.reportService.getAll(pageable));
     }
 
-    @Operation(
-            summary = "Resolve a report",
-            description = "Resolves a report, optionally applying a punishment template to the reported player",
-            operationId = "resolveReport",
-            tags = {"Report"}
-    )
-    @ApiResponse(
-            responseCode = "200",
-            description = "Report successfully resolved",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReportDTO.class))
-    )
-    @ApiResponse(responseCode = "404", description = "Report or punishment template not found")
-    @ApiResponse(responseCode = "400", description = "punishmentSource is required when punishmentTemplateId is set")
-    @Validated
-    @Post("/{identifier}/resolve")
-    public HttpResponse<?> resolve(UUID identifier, @Body @Valid ReportResolutionDTO resolution) {
+    @Override
+    public HttpResponse<?> resolve(UUID identifier, ReportResolutionDTO resolution) {
         ReportService.ResolveResult result = this.reportService.resolve(identifier, resolution);
         return switch (result) {
             case ReportService.ResolveResult.Success success -> HttpResponse.ok(success.report());

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/report/service/ReportService.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/report/service/ReportService.java
@@ -54,6 +54,17 @@ import java.util.UUID;
  * can be re-invoked on the same report, re-triggering its standing ELO effects each time - there
  * is no status state machine enforcing valid transitions. Preserved as-is; introducing one is a
  * separate, more invasive behavioral change.</p>
+ *
+ * <p><b>Known limitation (deferred, not fixed here):</b> {@code resolve}'s chain of side effects -
+ * optional punishment application, the report's own status/resolutionNote/resolvedBy/updatedAt
+ * update, up to two ELO deltas, and the final event publish - is not atomic. {@code @Transactional}
+ * is unusable in this codebase (see {@link EloService}'s class Javadoc for why). A failure partway
+ * through (e.g. the report {@code update()} throwing after
+ * {@code punishmentApplicationService.apply()} already succeeded) can leave a punishment applied
+ * against a report that never recorded its own resolution, or an ELO delta applied without the
+ * report reflecting the status that triggered it. This is an accepted race window in the same
+ * spirit as the one already documented for {@code EloService} and {@code AppealDecisionService},
+ * not newly introduced here.</p>
  */
 @Singleton
 public class ReportService {


### PR DESCRIPTION
## Summary
Implements two zero-behavior-change items from `specs/006-player-reports/tasks.md`'s Polish phase (T021, T023):

- **T023**: Extracts `ReportApi` (routing + `@Operation`/`@ApiResponse` annotations), `ReportController` now `implements` it — following the existing `PlayerLookupApi`/`PlayerLookupController` precedent in this codebase, per `micronaut-openapi-contract`.
- **T021**: Documents `ReportService.resolve()`'s multi-step side-effect chain (punishment apply → report update → up to two ELO deltas → event publish) as non-atomic in a class Javadoc, matching `EloService`'s and `AppealDecisionService`'s existing documented-limitation style.

**Deliberately not included**: T022 (consolidating `ReportDTO`/`ReportRequestDTO`/`ReportResolutionDTO` into a sealed `Error`-variant contract) — that changes wire format and touches the generated OpenAPI client, a real breaking-change risk that needs its own explicit scoping decision, not a blind implementation bundled with these two safe items.

## Test plan
- [x] `./gradlew :backend:compileJava` succeeds
- [x] Generated OpenAPI spec (`blackhole-api-*.yml`) still documents `submitReport`/`getReports`/`resolveReport` correctly after the interface extraction
- [x] Verified against real Docker infra: submit/list/resolve all still route and respond correctly through `ReportApi`, including `@Valid` request validation (invalid hash pattern → 400) still enforced via the interface-declared parameters