### PR TITLE
refactor(backend): extract punishment *Api interfaces, fix template-delete FK bug

### DIFF
--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/PunishmentRepository.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/PunishmentRepository.java
@@ -3,6 +3,16 @@ package net.onelitefeather.blackhole.backend.punishment;
 import io.micronaut.data.annotation.Repository;
 import io.micronaut.data.repository.PageableRepository;
 
+import java.util.UUID;
+
 @Repository
 public interface PunishmentRepository extends PageableRepository<PunishmentEntity, String> {
+
+    /**
+     * Whether any punishment still references the given template - checked before allowing a
+     * template to be deleted, since {@link PunishmentEntity#template} is a live FK with no
+     * {@code ON DELETE} cascade/set-null configured (see
+     * {@code specs/002-punishment-core/tasks.md} T029).
+     */
+    boolean existsByTemplate_Identifier(UUID templateIdentifier);
 }

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/RedisTopology.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/RedisTopology.java
@@ -4,6 +4,16 @@ package net.onelitefeather.blackhole.backend.punishment;
  * Well-known Redis channel/key names shared between {@link PunishmentRedisWriter} and every
  * Velocity proxy's read-side mirror - the key/channel format here must be replicated
  * byte-for-byte on the Velocity side.
+ *
+ * <p><b>Deliberately not env-var configurable</b> (unlike this project's usual
+ * {@code blackhole.*} tunables convention - see {@code application.yml}): these strings are a
+ * wire protocol between two independently-deployed and independently-configured processes (this
+ * backend and every Velocity proxy instance), not a single-side tunable. Making them
+ * configurable per-side would let the backend and a proxy silently drift onto mismatched
+ * keys/channels - a much worse failure mode (proxies quietly never see punishment updates) than
+ * the inflexibility of a fixed constant. If this ever needs to vary, it should be a single value
+ * distributed to both sides from one source, not two independent config surfaces
+ * (specs/002-punishment-core/tasks.md T031).</p>
  */
 public final class RedisTopology {
 

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/controller/PunishmentApi.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/controller/PunishmentApi.java
@@ -1,0 +1,130 @@
+package net.onelitefeather.blackhole.backend.punishment.controller;
+
+import net.onelitefeather.blackhole.backend.punishment.dto.PunishEntryDTO;
+import io.micronaut.data.model.Page;
+import io.micronaut.data.model.Pageable;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.validation.Validated;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import net.onelitefeather.blackhole.backend.profile.dto.PunishProfileResponse;
+
+import java.util.UUID;
+
+public interface PunishmentApi {
+
+    @Operation(
+            summary = "Add active punishment",
+            description = "Creates and applies an active punishment to a player profile based on a punishment template",
+            operationId = "addActivePunishment",
+            tags = {"Punishment"}
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Punishment successfully applied to profile",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PunishProfileResponse.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Profile or template not found"
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "Invalid input parameters (owner must be SHA-512 hash)"
+    )
+    @Validated
+    @Post("/active/{owner}/{templateId}/{source}")
+    HttpResponse<PunishProfileResponse> add(
+            @Valid @Pattern(regexp = "^[a-fA-F0-9]{128}$", message = "Owner must be a sha-512 hash") String owner,
+            UUID templateId,
+            UUID source
+    );
+
+    @Operation(
+            summary = "Revoke active ban",
+            description = "Revokes a player's active ban (SERVER or NETWORK), moving it into history",
+            operationId = "revokeBan",
+            tags = {"Punishment"}
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Ban successfully revoked",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PunishProfileResponse.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Profile not found, or has no active ban"
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "Invalid input parameters (owner must be SHA-512 hash)"
+    )
+    @Validated
+    @Post("/active/{owner}/ban/revoke/{source}")
+    HttpResponse<PunishProfileResponse> revokeBan(
+            @Valid @Pattern(regexp = "^[a-fA-F0-9]{128}$", message = "Owner must be a sha-512 hash") String owner,
+            UUID source
+    );
+
+    @Operation(
+            summary = "Revoke active mute",
+            description = "Revokes a player's active chat ban, moving it into history",
+            operationId = "revokeMute",
+            tags = {"Punishment"}
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Mute successfully revoked",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PunishProfileResponse.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Profile not found, or has no active mute"
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "Invalid input parameters (owner must be SHA-512 hash)"
+    )
+    @Validated
+    @Post("/active/{owner}/mute/revoke/{source}")
+    HttpResponse<PunishProfileResponse> revokeMute(
+            @Valid @Pattern(regexp = "^[a-fA-F0-9]{128}$", message = "Owner must be a sha-512 hash") String owner,
+            UUID source
+    );
+
+    @Operation(
+            summary = "Get all punishments",
+            description = "Retrieves a paginated list of all punishment entries in the system",
+            operationId = "getPunishments",
+            tags = {"Punishment"}
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Successfully retrieved punishment entries",
+            content = @Content(
+                    mediaType = "application/json",
+                    array = @ArraySchema(
+                            schema = @Schema(implementation = PunishEntryDTO.class),
+                            arraySchema = @Schema(implementation = Page.class)
+                    )
+            )
+    )
+    @Get()
+    HttpResponse<Page<PunishEntryDTO>> getAll(Pageable pageable);
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/controller/PunishmentEntityController.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/controller/PunishmentEntityController.java
@@ -7,26 +7,19 @@ import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Controller;
-import io.micronaut.http.annotation.Get;
-import io.micronaut.http.annotation.Post;
 import io.micronaut.core.version.annotation.Version;
-import io.micronaut.validation.Validated;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.inject.Inject;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Pattern;
 import net.onelitefeather.blackhole.backend.controller.ApiVersion;
 import net.onelitefeather.blackhole.backend.profile.dto.PunishProfileResponse;
 
 import java.util.UUID;
 
+/**
+ * Routing and OpenAPI annotations live on {@link PunishmentApi}, which this class implements.
+ */
 @Version(ApiVersion.V1)
 @Controller("/punishment")
-public class PunishmentEntityController {
+public class PunishmentEntityController implements PunishmentApi {
 
     private final PunishmentApplicationService punishmentApplicationService;
 
@@ -42,43 +35,8 @@ public class PunishmentEntityController {
         this.punishmentApplicationService = punishmentApplicationService;
     }
 
-    /**
-     * Set an active punishment to the database.
-     *
-     * @param owner the owner of the punishment
-     * @param templateId the template id of the punishment
-     * @param source the source of the punishment
-     * @return the added punishment
-     */
-    @Operation(
-            summary = "Add active punishment",
-            description = "Creates and applies an active punishment to a player profile based on a punishment template",
-            operationId = "addActivePunishment",
-            tags = {"Punishment"}
-    )
-    @ApiResponse(
-            responseCode = "200",
-            description = "Punishment successfully applied to profile",
-            content = @Content(
-                    mediaType = "application/json",
-                    schema = @Schema(implementation = PunishProfileResponse.class)
-            )
-    )
-    @ApiResponse(
-            responseCode = "404",
-            description = "Profile or template not found"
-    )
-    @ApiResponse(
-            responseCode = "400",
-            description = "Invalid input parameters (owner must be SHA-512 hash)"
-    )
-    @Validated
-    @Post("/active/{owner}/{templateId}/{source}")
-    public HttpResponse<PunishProfileResponse> add(
-            @Valid @Pattern(regexp = "^[a-fA-F0-9]{128}$", message = "Owner must be a sha-512 hash") String owner,
-            UUID templateId,
-            UUID source
-    ) {
+    @Override
+    public HttpResponse<PunishProfileResponse> add(String owner, UUID templateId, UUID source) {
         var profile = this.punishmentApplicationService.apply(owner, templateId, source);
         if (profile.isEmpty()) {
             return HttpResponse.notFound();
@@ -86,41 +44,8 @@ public class PunishmentEntityController {
         return HttpResponse.ok(profile.get().toDTO());
     }
 
-    /**
-     * Revoke an active ban.
-     *
-     * @param owner the owner of the punishment
-     * @param source the staff/system identity revoking the punishment
-     * @return the updated profile
-     */
-    @Operation(
-            summary = "Revoke active ban",
-            description = "Revokes a player's active ban (SERVER or NETWORK), moving it into history",
-            operationId = "revokeBan",
-            tags = {"Punishment"}
-    )
-    @ApiResponse(
-            responseCode = "200",
-            description = "Ban successfully revoked",
-            content = @Content(
-                    mediaType = "application/json",
-                    schema = @Schema(implementation = PunishProfileResponse.class)
-            )
-    )
-    @ApiResponse(
-            responseCode = "404",
-            description = "Profile not found, or has no active ban"
-    )
-    @ApiResponse(
-            responseCode = "400",
-            description = "Invalid input parameters (owner must be SHA-512 hash)"
-    )
-    @Validated
-    @Post("/active/{owner}/ban/revoke/{source}")
-    public HttpResponse<PunishProfileResponse> revokeBan(
-            @Valid @Pattern(regexp = "^[a-fA-F0-9]{128}$", message = "Owner must be a sha-512 hash") String owner,
-            UUID source
-    ) {
+    @Override
+    public HttpResponse<PunishProfileResponse> revokeBan(String owner, UUID source) {
         var profile = this.punishmentApplicationService.revokeBan(owner, source);
         if (profile.isEmpty()) {
             return HttpResponse.notFound();
@@ -128,41 +53,8 @@ public class PunishmentEntityController {
         return HttpResponse.ok(profile.get().toDTO());
     }
 
-    /**
-     * Revoke an active mute.
-     *
-     * @param owner the owner of the punishment
-     * @param source the staff/system identity revoking the punishment
-     * @return the updated profile
-     */
-    @Operation(
-            summary = "Revoke active mute",
-            description = "Revokes a player's active chat ban, moving it into history",
-            operationId = "revokeMute",
-            tags = {"Punishment"}
-    )
-    @ApiResponse(
-            responseCode = "200",
-            description = "Mute successfully revoked",
-            content = @Content(
-                    mediaType = "application/json",
-                    schema = @Schema(implementation = PunishProfileResponse.class)
-            )
-    )
-    @ApiResponse(
-            responseCode = "404",
-            description = "Profile not found, or has no active mute"
-    )
-    @ApiResponse(
-            responseCode = "400",
-            description = "Invalid input parameters (owner must be SHA-512 hash)"
-    )
-    @Validated
-    @Post("/active/{owner}/mute/revoke/{source}")
-    public HttpResponse<PunishProfileResponse> revokeMute(
-            @Valid @Pattern(regexp = "^[a-fA-F0-9]{128}$", message = "Owner must be a sha-512 hash") String owner,
-            UUID source
-    ) {
+    @Override
+    public HttpResponse<PunishProfileResponse> revokeMute(String owner, UUID source) {
         var profile = this.punishmentApplicationService.revokeMute(owner, source);
         if (profile.isEmpty()) {
             return HttpResponse.notFound();
@@ -170,29 +62,7 @@ public class PunishmentEntityController {
         return HttpResponse.ok(profile.get().toDTO());
     }
 
-    /**
-     * Get all punishments from the database.
-     *
-     * @return a list with all punishments
-     */
-    @Operation(
-            summary = "Get all punishments",
-            description = "Retrieves a paginated list of all punishment entries in the system",
-            operationId = "getPunishments",
-            tags = {"Punishment"}
-    )
-    @ApiResponse(
-            responseCode = "200",
-            description = "Successfully retrieved punishment entries",
-            content = @Content(
-                    mediaType = "application/json",
-                    array = @ArraySchema(
-                            schema = @Schema(implementation = PunishEntryDTO.class),
-                            arraySchema = @Schema(implementation = Page.class)
-                    )
-            )
-    )
-    @Get()
+    @Override
     public HttpResponse<Page<PunishEntryDTO>> getAll(Pageable pageable) {
         Page<PunishmentEntity> entries = this.punishmentApplicationService.findAll(pageable);
         return HttpResponse.ok(entries.map(PunishmentEntity::toDTO));

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/controller/PunishmentTemplateApi.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/controller/PunishmentTemplateApi.java
@@ -1,0 +1,139 @@
+package net.onelitefeather.blackhole.backend.punishment.controller;
+
+import net.onelitefeather.blackhole.backend.punishment.dto.PunishTemplateDTO;
+import net.onelitefeather.blackhole.backend.punishment.dto.PunishTemplateRequestDTO;
+import io.micronaut.data.model.Page;
+import io.micronaut.data.model.Pageable;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.PathVariable;
+import io.micronaut.http.annotation.Post;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+
+import java.util.UUID;
+
+public interface PunishmentTemplateApi {
+
+    @Operation(
+            summary = "Create punishment template",
+            description = "Creates a new punishment template.",
+            operationId = "addTemplate",
+            tags = {"Punishment Templates"}
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Template successfully created",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PunishTemplateDTO.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "405",
+            description = "Method not allowed - identifier must be null for creation"
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "Invalid template data"
+    )
+    @Post("/")
+    HttpResponse<PunishTemplateDTO> addTemplate(@Valid @Body PunishTemplateRequestDTO template);
+
+    @Operation(
+            summary = "Update punishment template",
+            description = "Updates an existing punishment template.",
+            operationId = "updateTemplate",
+            tags = {"Punishment Templates"}
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Template successfully updated",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PunishTemplateDTO.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Template not found"
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "Invalid template data"
+    )
+    @Post(value = "/update")
+    HttpResponse<PunishTemplateDTO> updateTemplate(@Valid @Body PunishTemplateRequestDTO template);
+
+    @Operation(
+            summary = "Delete punishment template",
+            description = "Deletes a punishment template by its identifier",
+            operationId = "deleteTemplate",
+            tags = {"Punishment Templates"}
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Template successfully deleted",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PunishTemplateDTO.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Template not found"
+    )
+    @ApiResponse(
+            responseCode = "409",
+            description = "At least one punishment still references this template"
+    )
+    @Delete(value = "/delete/{identifier}")
+    HttpResponse<?> removeTemplate(@PathVariable UUID identifier);
+
+    @Operation(
+            summary = "Get all punishment templates",
+            description = "Retrieves a paginated list of all punishment templates in the system",
+            operationId = "getAllTemplates",
+            tags = {"Punishment Templates"}
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Successfully retrieved punishment templates",
+            content = @Content(
+                    mediaType = "application/json",
+                    array = @ArraySchema(
+                            schema = @Schema(implementation = PunishTemplateDTO.class),
+                            arraySchema = @Schema(implementation = Page.class)
+                    )
+            )
+    )
+    @Get("/")
+    HttpResponse<Page<PunishTemplateDTO>> getAll(Pageable pageable);
+
+    @Operation(
+            summary = "Get punishment template by ID",
+            description = "Retrieves a specific punishment template by its identifier",
+            operationId = "getTemplateById",
+            tags = {"Punishment Templates"}
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Template successfully retrieved",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PunishTemplateDTO.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Template not found"
+    )
+    @Get("/{identifier}")
+    HttpResponse<PunishTemplateDTO> get(UUID identifier);
+}

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/controller/PunishmentTemplateController.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/controller/PunishmentTemplateController.java
@@ -6,26 +6,17 @@ import net.onelitefeather.blackhole.backend.punishment.service.PunishmentTemplat
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.annotation.Body;
+import io.micronaut.http.HttpStatus;
 import io.micronaut.http.annotation.Controller;
-import io.micronaut.http.annotation.Delete;
-import io.micronaut.http.annotation.Get;
-import io.micronaut.http.annotation.PathVariable;
-import io.micronaut.http.annotation.Post;
 import io.micronaut.core.version.annotation.Version;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.inject.Inject;
-import jakarta.validation.Valid;
 import net.onelitefeather.blackhole.backend.controller.ApiVersion;
 
 import java.util.UUID;
 
 /**
- * A handler for punishment templates.
+ * A handler for punishment templates. Routing and OpenAPI annotations live on
+ * {@link PunishmentTemplateApi}, which this class implements.
  *
  * @author theEvilReaper
  * @version 1.0.0
@@ -33,7 +24,7 @@ import java.util.UUID;
  */
 @Version(ApiVersion.V1)
 @Controller("/template")
-public class PunishmentTemplateController {
+public class PunishmentTemplateController implements PunishmentTemplateApi {
 
     private final PunishmentTemplateService templateService;
 
@@ -47,72 +38,16 @@ public class PunishmentTemplateController {
         this.templateService = templateService;
     }
 
-    /**
-     * Add a template to the database.
-     *
-     * @param template the template to add
-     * @return the added template
-     */
-    @Operation(
-            summary = "Create punishment template",
-            description = "Creates a new punishment template.",
-            operationId = "addTemplate",
-            tags = {"Punishment Templates"}
-    )
-    @ApiResponse(
-            responseCode = "200",
-            description = "Template successfully created",
-            content = @Content(
-                    mediaType = "application/json",
-                    schema = @Schema(implementation = PunishTemplateDTO.class)
-            )
-    )
-    @ApiResponse(
-            responseCode = "405",
-            description = "Method not allowed - identifier must be null for creation"
-    )
-    @ApiResponse(
-            responseCode = "400",
-            description = "Invalid template data"
-    )
-    @Post("/")
-    public HttpResponse<PunishTemplateDTO> addTemplate(@Valid @Body PunishTemplateRequestDTO template) {
+    @Override
+    public HttpResponse<PunishTemplateDTO> addTemplate(PunishTemplateRequestDTO template) {
         return switch (this.templateService.create(template)) {
             case PunishmentTemplateService.CreateResult.Created created -> HttpResponse.ok(created.template());
             case PunishmentTemplateService.CreateResult.IdentifierNotAllowed ignored -> HttpResponse.notAllowed();
         };
     }
 
-    /**
-     * Update a template in the database.
-     *
-     * @param template the template to update
-     * @return the updated template
-     */
-    @Operation(
-            summary = "Update punishment template",
-            description = "Updates an existing punishment template.",
-            operationId = "updateTemplate",
-            tags = {"Punishment Templates"}
-    )
-    @ApiResponse(
-            responseCode = "200",
-            description = "Template successfully updated",
-            content = @Content(
-                    mediaType = "application/json",
-                    schema = @Schema(implementation = PunishTemplateDTO.class)
-            )
-    )
-    @ApiResponse(
-            responseCode = "404",
-            description = "Template not found"
-    )
-    @ApiResponse(
-            responseCode = "400",
-            description = "Invalid template data"
-    )
-    @Post(value = "/update")
-    public HttpResponse<PunishTemplateDTO> updateTemplate(@Valid @Body PunishTemplateRequestDTO template) {
+    @Override
+    public HttpResponse<PunishTemplateDTO> updateTemplate(PunishTemplateRequestDTO template) {
         return switch (this.templateService.update(template)) {
             case PunishmentTemplateService.UpdateResult.Updated updated -> HttpResponse.ok(updated.template());
             case PunishmentTemplateService.UpdateResult.MissingIdentifier ignored -> HttpResponse.badRequest();
@@ -120,89 +55,22 @@ public class PunishmentTemplateController {
         };
     }
 
-    /**
-     * Remove a template from the database.
-     *
-     * @param identifier the identifier of the template to remove
-     * @return the removed template
-     */
-    @Operation(
-            summary = "Delete punishment template",
-            description = "Deletes a punishment template by its identifier",
-            operationId = "deleteTemplate",
-            tags = {"Punishment Templates"}
-    )
-    @ApiResponse(
-            responseCode = "200",
-            description = "Template successfully deleted",
-            content = @Content(
-                    mediaType = "application/json",
-                    schema = @Schema(implementation = PunishTemplateDTO.class)
-            )
-    )
-    @ApiResponse(
-            responseCode = "404",
-            description = "Template not found"
-    )
-    @Delete(value = "/delete/{identifier}")
-    public HttpResponse<PunishTemplateDTO> removeTemplate(@PathVariable UUID identifier) {
-        return this.templateService.remove(identifier)
-                .map(HttpResponse::ok)
-                .orElseGet(HttpResponse::notFound);
+    @Override
+    public HttpResponse<?> removeTemplate(UUID identifier) {
+        return switch (this.templateService.remove(identifier)) {
+            case PunishmentTemplateService.RemoveResult.Removed removed -> HttpResponse.ok(removed.template());
+            case PunishmentTemplateService.RemoveResult.NotFound ignored -> HttpResponse.notFound();
+            case PunishmentTemplateService.RemoveResult.InUse ignored ->
+                    HttpResponse.status(HttpStatus.CONFLICT, "At least one punishment still references this template");
+        };
     }
 
-    /**
-     * Get all templates from the database.
-     *
-     * @return a list of all templates
-     */
-    @Operation(
-            summary = "Get all punishment templates",
-            description = "Retrieves a paginated list of all punishment templates in the system",
-            operationId = "getAllTemplates",
-            tags = {"Punishment Templates"}
-    )
-    @ApiResponse(
-            responseCode = "200",
-            description = "Successfully retrieved punishment templates",
-            content = @Content(
-                    mediaType = "application/json",
-                    array = @ArraySchema(
-                            schema = @Schema(implementation = PunishTemplateDTO.class),
-                            arraySchema = @Schema(implementation = Page.class)
-                    )
-            )
-    )
-    @Get("/")
+    @Override
     public HttpResponse<Page<PunishTemplateDTO>> getAll(Pageable pageable) {
         return HttpResponse.ok(this.templateService.findAll(pageable));
     }
 
-    /**
-     * Get a template by identifier from the database.
-     *
-     * @param identifier the identifier of the template to retrieve
-     * @return the template if found
-     */
-    @Operation(
-            summary = "Get punishment template by ID",
-            description = "Retrieves a specific punishment template by its identifier",
-            operationId = "getTemplateById",
-            tags = {"Punishment Templates"}
-    )
-    @ApiResponse(
-            responseCode = "200",
-            description = "Template successfully retrieved",
-            content = @Content(
-                    mediaType = "application/json",
-                    schema = @Schema(implementation = PunishTemplateDTO.class)
-            )
-    )
-    @ApiResponse(
-            responseCode = "404",
-            description = "Template not found"
-    )
-    @Get("/{identifier}")
+    @Override
     public HttpResponse<PunishTemplateDTO> get(UUID identifier) {
         return this.templateService.find(identifier)
                 .map(HttpResponse::ok)

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/service/PunishmentApplicationService.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/service/PunishmentApplicationService.java
@@ -37,6 +37,17 @@ import java.util.UUID;
  * publishing rather than duplicating it. Being the one chokepoint every punishment goes through
  * is also why a template's {@code eloDelta} is applied here rather than in each caller - it's
  * the only place guaranteed to see every temp-ban regardless of who/what issued it.
+ *
+ * <p><b>Known limitation (deferred, not fixed here):</b> {@link #apply}'s read-profile /
+ * save-punishment / optionally-apply-ELO-delta / rotate-active-slot / update-profile sequence,
+ * and {@link #revoke}'s equivalent read-modify-write, are not atomic - {@code @Transactional} is
+ * unusable in this codebase (see {@code EloService}'s class Javadoc for why). Two concurrent
+ * applications to the same owner+track could both read the same "no active punishment yet" state
+ * and both attempt to occupy the same slot; the unique DB constraint on
+ * {@code active_ban_identifier}/{@code active_chat_ban_identifier} rejects the second write
+ * rather than silently double-occupying the slot, but the caller sees an unhandled persistence
+ * exception rather than a clean "conflict" response. This is an accepted race window in the same
+ * spirit as the one already documented for {@code EloService}, not newly introduced here.</p>
  */
 @Singleton
 public class PunishmentApplicationService {

--- a/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/service/PunishmentTemplateService.java
+++ b/backend/src/main/java/net/onelitefeather/blackhole/backend/punishment/service/PunishmentTemplateService.java
@@ -1,5 +1,6 @@
 package net.onelitefeather.blackhole.backend.punishment.service;
 
+import net.onelitefeather.blackhole.backend.punishment.PunishmentRepository;
 import net.onelitefeather.blackhole.backend.punishment.PunishmentTemplateEntity;
 import net.onelitefeather.blackhole.backend.punishment.PunishmentTemplateRepository;
 import net.onelitefeather.blackhole.backend.punishment.dto.PunishTemplateDTO;
@@ -22,9 +23,11 @@ import java.util.UUID;
 public class PunishmentTemplateService {
 
     private final PunishmentTemplateRepository templateRepository;
+    private final PunishmentRepository punishmentRepository;
 
-    public PunishmentTemplateService(PunishmentTemplateRepository templateRepository) {
+    public PunishmentTemplateService(PunishmentTemplateRepository templateRepository, PunishmentRepository punishmentRepository) {
         this.templateRepository = templateRepository;
+        this.punishmentRepository = punishmentRepository;
     }
 
     /**
@@ -55,14 +58,24 @@ public class PunishmentTemplateService {
     }
 
     /**
-     * Deletes the template with {@code identifier}, returning its DTO, or empty if no template
-     * with that identifier exists.
+     * Deletes the template with {@code identifier} - see {@link RemoveResult.NotFound} /
+     * {@link RemoveResult.InUse}. Checks for referencing punishments first rather than letting
+     * the delete fail at the database level: {@code PunishmentEntity.template} is a live FK with
+     * no {@code ON DELETE} cascade/set-null configured, so an unchecked delete previously threw
+     * an unhandled foreign-key-constraint exception once any punishment had been created from the
+     * template - contradicting spec US5 Acceptance Scenario 3 and FR-010's "let network operators
+     * ... remove" a template (specs/002-punishment-core/tasks.md T029).
      */
-    public Optional<PunishTemplateDTO> remove(UUID identifier) {
-        return this.templateRepository.findById(identifier).map(entity -> {
-            this.templateRepository.delete(entity);
-            return entity.toDTO();
-        });
+    public RemoveResult remove(UUID identifier) {
+        PunishmentTemplateEntity entity = this.templateRepository.findById(identifier).orElse(null);
+        if (entity == null) {
+            return new RemoveResult.NotFound();
+        }
+        if (this.punishmentRepository.existsByTemplate_Identifier(identifier)) {
+            return new RemoveResult.InUse();
+        }
+        this.templateRepository.delete(entity);
+        return new RemoveResult.Removed(entity.toDTO());
     }
 
     /**
@@ -103,6 +116,22 @@ public class PunishmentTemplateService {
         }
 
         record NotFound() implements UpdateResult {
+        }
+    }
+
+    /**
+     * Outcome of {@link #remove(UUID)}, mapped 1:1 to an {@code HttpResponse} by the controller
+     * instead of the controller re-deriving what happened.
+     */
+    public sealed interface RemoveResult {
+        record Removed(PunishTemplateDTO template) implements RemoveResult {
+        }
+
+        record NotFound() implements RemoveResult {
+        }
+
+        /** At least one punishment still references this template - see {@link #remove(UUID)}. */
+        record InUse() implements RemoveResult {
         }
     }
 }


### PR DESCRIPTION
## Summary
Four items from `specs/002-punishment-core/tasks.md`'s Polish phase:

- **T027**: Extracts `PunishmentApi` and `PunishmentTemplateApi` (routing + `@Operation`/`@ApiResponse`), both controllers now `implement` their interface per `micronaut-openapi-contract`, following the existing `PlayerLookupApi` precedent in this codebase.
- **T025**: Documents `PunishmentApplicationService.apply`/`revoke`'s read-modify-write race window in a class Javadoc, matching `EloService`'s documented-limitation style.
- **T029 — a real correctness bug, not just layering**: `DELETE /template/delete/{id}` previously let an unhandled DB foreign-key exception surface as a raw `500` whenever a punishment still referenced the template — contradicting spec US5 Acceptance Scenario 3 and FR-010's "let network operators... remove" a template. `PunishmentTemplateService.remove()` now checks `PunishmentRepository.existsByTemplate_Identifier` first and returns a clean **409 Conflict** instead.
- **T031**: Documents `RedisTopology`'s hardcoded key/channel constants as intentional — it's a wire protocol shared with every Velocity proxy, not a per-side tunable, so making it independently env-var configurable on each side risks silent drift/mismatch between backend and proxy.

**Deliberately not included**: T026 (DTO/`Error`-variant consolidation) and T028 (snapshotting a template's `reason` onto `PunishmentEntity`, which needs a new Liquibase changeset) — both real, higher-risk changes (breaking wire format / a schema migration) that need their own explicit scoping decision.

## Test plan
- [x] `./gradlew :backend:compileJava` succeeds
- [x] Generated OpenAPI spec still documents all moved endpoints correctly
- [x] Verified against real Docker infra: template create/update/get/getAll, punishment apply/revoke/getAll all unaffected; **specifically confirmed the T029 fix** — created a template, applied a punishment from it, then confirmed `DELETE /template/delete/{id}` now returns `409` instead of an unhandled `500`; confirmed deleting an unused template still returns `200`, and a nonexistent template still returns `404`